### PR TITLE
chore: Automate telemetry updates

### DIFF
--- a/.github/workflows/telemetry.yml
+++ b/.github/workflows/telemetry.yml
@@ -1,0 +1,85 @@
+name: Update Telemetry
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '36 14 * * MON'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Azure login
+        if: github.ref == 'refs/heads/main'
+        uses: Azure/login@v2
+        with:
+          client-id: ${{ secrets.APPINSIGHTS_CLIENTID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Update telemetry
+        shell: pwsh
+        env:
+          WORKSPACEID: ${{ secrets.APPINSIGHTS_WORKSPACEID }}
+        run: |
+          # Import build functions and AppInsights queries
+          . .\build.functions.ps1
+          # Build list of commands from the MilestonePSTools module
+          $module = Find-Module MilestonePSTools
+          $commands = @{}
+          $module.AdditionalMetadata.Functions -split '\s+' | ForEach-Object {
+              $commands[$_] = $null
+          }
+          $module.AdditionalMetadata.Cmdlets -split '\s+' | ForEach-Object {
+              $commands[$_] = $null
+          }
+          # Scrape download count from PSGallery
+          $html = Invoke-WebRequest https://www.powershellgallery.com/packages/milestonePSTools
+          $downloadMatch = $html.RawContent | Select-String '<li class="package-details-info-main">\s+(?<downloads>[\d,]+)'
+          $downloads = [int]$downloadMatch.Matches[0].Groups['downloads'].Value
+          # Query AppInsights and generate JSON
+          # Retrieve token for AppInsights query
+          $token = (az account get-access-token --resource https://api.loganalytics.io | ConvertFrom-Json).accessToken
+          $splat = @{
+             WorkspaceId = $env:WORKSPACEID
+             Token       = $token
+          }
+          $telemetry = [pscustomobject]@{
+              LastUpdated    = Get-Date -AsUTC
+              Downloads      = $downloads
+              TotalSessions  = Invoke-AzWorkspaceQuery @splat -Query $AppInsightsQueries.TotalSessions | % TotalSessions
+              TotalUsers     = Invoke-AzWorkspaceQuery @splat -Query $AppInsightsQueries.TotalUsers | % TotalUsers
+              TotalSites     = Invoke-AzWorkspaceQuery @splat -Query $AppInsightsQueries.TotalSites | % TotalSites
+              TotalCameras   = Invoke-AzWorkspaceQuery @splat -Query $AppInsightsQueries.TotalCameras | % TotalCameras
+              TotalCountries = Invoke-AzWorkspaceQuery @splat -Query $AppInsightsQueries.TotalCountries | % TotalCountries
+              CommandUsage   = Invoke-AzWorkspaceQuery @splat -Query $AppInsightsQueries.CommandUsage | Where-Object {
+                  $commands.ContainsKey($_.Command)
+              }
+          } | ConvertTo-Json
+          # Write telemetry to file and create PR
+          $telemetry | Set-Content ./docs/telemetry.json
+
+      - name: Open pull-request
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Exit early if no changes have been made to telemetry.json
+          if ('docs/telemetry.json' -notin (git diff --name-only)) {
+            exit 0
+          }
+          $branchName = 'update-telemetry-{0}' -f (Get-Date -Format 'yyyyMMdd-HHmmss')
+          git config --global user.name "github-actions"
+          git config --global user.email "github-actions@github.com"
+          git checkout -b $branchName
+          git add ./docs/telemetry.json
+          git commit -m "chore: Automated telemetry update"
+          git push --set-upstream origin $branchName
+          gh pr create -B main -H $branchName -t "Automated telemetry update" -b 'Automated telemetry update'

--- a/build.functions.ps1
+++ b/build.functions.ps1
@@ -1267,3 +1267,60 @@ _usage based on optional telemetry_
         throw
     }
 }
+
+$script:AppInsightsQueries = @{
+
+    TotalSessions = @'
+AppEvents
+| where TimeGenerated  > ago(30d)
+| where Name == "NewVmsConnection"
+| where not(tostring(Properties.ProductName) matches regex "(Test)$")
+| distinct SessionId
+| summarize TotalSessions = count()
+'@
+
+    TotalUsers = @'
+AppEvents
+| where TimeGenerated  > ago(30d)
+| where Name == "NewVmsConnection"
+| where not(tostring(Properties.ProductName) matches regex "(Test)$")
+| distinct UserId
+| summarize TotalUsers = count()
+'@
+
+    TotalCameras = @'
+AppEvents
+| where TimeGenerated > ago(30d)
+| where Name == "NewVmsConnection"
+| where not(tostring(Properties.ProductName) matches regex "(Test)$")
+| extend CamerasOnSite = todouble(Measurements["CameraCount"]), SiteId = tostring(Properties["SiteId"])
+| summarize arg_max(TimeGenerated, *) by SiteId
+| summarize TotalCameras = sum(CamerasOnSite)
+'@
+
+    TotalCountries = @'
+AppEvents
+| where TimeGenerated > ago(30d)
+| where Name == "NewVmsConnection"
+| where not(tostring(Properties.ProductName) matches regex "(Test)$")
+| summarize TotalCountries = dcount(ClientCountryOrRegion)
+'@
+
+    TotalSites = @'
+AppEvents
+| where TimeGenerated > ago(30d)
+| where Name == "NewVmsConnection"
+| where not(tostring(Properties.ProductName) matches regex "(Test)$")
+| extend SiteId = tostring(Properties["SiteId"])
+| summarize TotalSites = dcount(SiteId)
+'@
+
+    CommandUsage = @'
+AppEvents
+| where TimeGenerated > ago(30d)
+| where Name == "InvokeCommand"
+| extend Command = tostring(Properties.Command)
+| summarize InvocationCount = count(), UserCount = dcount(UserId) by Command
+| order by Command asc
+'@
+}

--- a/docs/telemetry.json
+++ b/docs/telemetry.json
@@ -1,0 +1,131 @@
+{
+  "LastUpdated": "2025-06-09T17:47:54.3702187Z",
+  "Downloads": 455395,
+  "TotalSessions": 235550,
+  "TotalUsers": 901,
+  "TotalSites": 1168,
+  "TotalCameras": 548799,
+  "TotalCountries": 47,
+  "CommandUsage": [
+    {
+      "Command": "Add-VmsDeviceGroupMember",
+      "InvocationCount": 1,
+      "UserCount": 1
+    },
+    {
+      "Command": "Clear-VmsCache",
+      "InvocationCount": 1,
+      "UserCount": 1
+    },
+    {
+      "Command": "Connect-ManagementServer",
+      "InvocationCount": 5,
+      "UserCount": 4
+    },
+    {
+      "Command": "Connect-Vms",
+      "InvocationCount": 14,
+      "UserCount": 11
+    },
+    {
+      "Command": "Disconnect-ManagementServer",
+      "InvocationCount": 3,
+      "UserCount": 3
+    },
+    {
+      "Command": "Export-VmsHardware",
+      "InvocationCount": 3,
+      "UserCount": 3
+    },
+    {
+      "Command": "Get-HardwareSetting",
+      "InvocationCount": 1,
+      "UserCount": 1
+    },
+    {
+      "Command": "Get-IServerCommandService",
+      "InvocationCount": 3,
+      "UserCount": 2
+    },
+    {
+      "Command": "Get-VmsCamera",
+      "InvocationCount": 1,
+      "UserCount": 1
+    },
+    {
+      "Command": "Get-VmsCameraReport",
+      "InvocationCount": 3,
+      "UserCount": 2
+    },
+    {
+      "Command": "Get-VmsDeviceGroup",
+      "InvocationCount": 2,
+      "UserCount": 2
+    },
+    {
+      "Command": "Get-VmsHardware",
+      "InvocationCount": 5,
+      "UserCount": 5
+    },
+    {
+      "Command": "Get-VmsHardwareDriver",
+      "InvocationCount": 1,
+      "UserCount": 1
+    },
+    {
+      "Command": "Get-VmsManagementServer",
+      "InvocationCount": 2,
+      "UserCount": 2
+    },
+    {
+      "Command": "Get-VmsRecordingServer",
+      "InvocationCount": 4,
+      "UserCount": 4
+    },
+    {
+      "Command": "Get-VmsSite",
+      "InvocationCount": 1,
+      "UserCount": 1
+    },
+    {
+      "Command": "Get-VmsStorage",
+      "InvocationCount": 1,
+      "UserCount": 1
+    },
+    {
+      "Command": "Get-VmsToken",
+      "InvocationCount": 3,
+      "UserCount": 2
+    },
+    {
+      "Command": "Invoke-ServerConfigurator",
+      "InvocationCount": 1,
+      "UserCount": 1
+    },
+    {
+      "Command": "New-VmsDeviceGroup",
+      "InvocationCount": 1,
+      "UserCount": 1
+    },
+    {
+      "Command": "Remove-VmsDeviceGroup",
+      "InvocationCount": 1,
+      "UserCount": 1
+    },
+    {
+      "Command": "Remove-VmsStorage",
+      "InvocationCount": 1,
+      "UserCount": 1
+    },
+    {
+      "Command": "Set-VmsDeviceGroup",
+      "InvocationCount": 1,
+      "UserCount": 1
+    },
+    {
+      "Command": "Set-VmsHardwareDriver",
+      "InvocationCount": 1,
+      "UserCount": 1
+    }
+  ]
+}

--- a/docs/telemetry.md.template
+++ b/docs/telemetry.md.template
@@ -1,36 +1,44 @@
 ____________
 
-## In the last 30 days[^1]
+## In the last 30 days[^1][^2][^3]
 
 [^1]: Module usage is based on [optional telemetry](commands/en-US/about_Telemetry.md).
+[^2]: Numbers exclude telemetry related to test licenses.
+[^3]: Last updated on Monday, June 9, 2025.
 
 <div class="grid cards" markdown>
 
--   :octicons-device-camera-video-24:{ .lg .middle } __564,513 cameras__
+-   :octicons-device-camera-video-24:{ .lg .middle } __548,799 cameras__
 
     ---
 
-    More than 564k cameras have been managed by MilestonePSTools globally.
+    More than 548k cameras have been managed by MilestonePSTools globally.
 
--   :octicons-globe-24:{ .lg .middle } __48 countries__
-
-    ---
-
-    MilestonePSTools was used in at least 48 countries across the globe.
-
--   :fontawesome-solid-user-group:{ .lg .middle } __1020 active users__
+-   :fontawesome-solid-server:{ .lg .middle } __1168 sites__
 
     ---
 
-    In the last 30 days, at least 1020 unique customers have used MilestonePSTools.
+    MilestonePSTools has been used on at least 1168 sites in the last 30 days.
 
--   :material-login:{ .lg .middle } __235,977 sessions__
+-   :octicons-globe-24:{ .lg .middle } __47 countries__
+
+    ---
+
+    MilestonePSTools was used in at least 47 countries across the globe.
+
+-   :fontawesome-solid-user-group:{ .lg .middle } __901 active users__
+
+    ---
+
+    In the last 30 days, at least 901 unique customers have used MilestonePSTools.
+
+-   :material-login:{ .lg .middle } __235,550 sessions__
 
     ---
 
     There have been more than 235k PowerShell sessions using MilestonePSTools in the last 30 days.
 
--   :material-download:{ .lg .middle } __455,350 downloads__
+-   :material-download:{ .lg .middle } __455,395 downloads__
 
     ---
 


### PR DESCRIPTION
This PR adds a new workflow, `telemetry.yml`, which authenticates with Azure and runs a number of KQL queries to retrieve module telemetry data and update `docs/telemetry.json` with the most recent telemetry.

The workflow commits the change to a new branch, and creates a PR for human review and merging. The workflow runs every Monday or on `workflow_dispatch`.

On merge of the PR, the `Docs.yml` workflow will automatically run due to the modified file at `docs/telemetry.json`, and a new psake task will update the `docs/telemetry.md.template` file to inject the telemetry data from the updated JSON file. In the end, the telemetry on the docs site home page will be automatically updated every monday (after human PR review).