### PR TITLE
Fix error with ByStorage parameterset on Remove-VmsArchiveStorage

### DIFF
--- a/MilestonePSTools/Public/Storage/Remove-VmsArchiveStorage.ps1
+++ b/MilestonePSTools/Public/Storage/Remove-VmsArchiveStorage.ps1
@@ -43,8 +43,8 @@ function Remove-VmsArchiveStorage {
             }
 
             'ByStorage' {
-                $recorder = [VideoOS.Platform.ConfigurationItems.RecordingServer]::new((Get-VmsManagementServer).ServerId, $Storage.ParentItemPath)
                 $storage = [VideoOS.Platform.ConfigurationItems.Storage]::new((Get-VmsManagementServer).ServerId, $ArchiveStorage.ParentItemPath)
+                $recorder = [VideoOS.Platform.ConfigurationItems.RecordingServer]::new((Get-VmsManagementServer).ServerId, $Storage.ParentItemPath)
                 if ($PSCmdlet.ShouldProcess("Recording server $($recorder.Name)", "Delete archive $($ArchiveStorage.Name) from $($storage.Name)")) {
                     $folder = [VideoOS.Platform.ConfigurationItems.ArchiveStorageFolder]::new((Get-VmsManagementServer).ServerId, $ArchiveStorage.ParentPath)
                     [void]$folder.RemoveArchiveStorage($ArchiveStorage.Path)


### PR DESCRIPTION
When removing an archive storage using the `ByStorage` parameter set, an error was thrown:

```powershell
Exception calling ".ctor" with "2" argument(s): "Object reference not set to an instance of an object."
At C:\Users\jh\Documents\WindowsPowerShell\Modules\MilestonePSTools\25.2.6\MilestonePSTools.psm1:16451 char:17
+ ...             $recorder = [VideoOS.Platform.ConfigurationItems.Recordin ...
+                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [], MethodInvocationException
    + FullyQualifiedErrorId : NullReferenceException
```

The error was the result of trying to create a recorder instance using the value of `$Storage.ParentItemPath`, but `$Storage` was not yet defined.