### PR TITLE
fix: Add FailoverSettingValues to excluded properties

### DIFF
--- a/MilestonePSTools/Private/ImportVmsHardwareExcelFunctions.ps1
+++ b/MilestonePSTools/Private/ImportVmsHardwareExcelFunctions.ps1
@@ -181,7 +181,7 @@ function Get-DevicePropertyList {
     )
 
     begin {
-        $excludedProperties = 'Icon', 'ItemCategory', 'Methods', 'ServerId', 'CreatedDate', 'DisplayName', 'ParentItemPath', 'StreamDefinitions', 'StreamUsages', 'Guid'
+        $excludedProperties = 'Icon', 'ItemCategory', 'Methods', 'ServerId', 'CreatedDate', 'DisplayName', 'ParentItemPath', 'StreamDefinitions', 'StreamUsages', 'Guid', 'FailoverSettingValues'
         $orderPriority = 'Name', 'ShortName', 'HostName', 'WebServerUri', 'Address', 'UserName', 'Password', 'Enabled', 'Channel', 'GisPoint', 'ActiveWebServerUri', 'PublicAccessEnabled', 'PublicWebserverHostName', 'PublicWebserverPort'
         $rearOrderPriority = 'LastModified', 'Id'
 
@@ -511,7 +511,7 @@ function Import-DevicePropertyList {
     )
 
     begin {
-        $ignoredColumns = 'RecordingServer', 'Hardware', 'Address', 'LastModified', 'Id', 'MotionDetectionMethod', 'MotionGenerateMotionMetadata', 'MotionGridSize', 'MotionExcludeRegions', 'MotionHardwareAccelerationMode', 'MotionKeyframesOnly', 'MotionManualSensitivity', 'MotionManualSensitivityEnabled', 'MotionProcessTime', 'MotionThreshold', 'MotionUseExcludeRegions', 'PrivacyMaskXml', 'PausePatrollingTimeout', 'ReservedPTZTimeout', 'MulticastEnabled', 'Guid'
+        $ignoredColumns = 'RecordingServer', 'Hardware', 'Address', 'LastModified', 'Id', 'MotionDetectionMethod', 'MotionGenerateMotionMetadata', 'MotionGridSize', 'MotionExcludeRegions', 'MotionHardwareAccelerationMode', 'MotionKeyframesOnly', 'MotionManualSensitivity', 'MotionManualSensitivityEnabled', 'MotionProcessTime', 'MotionThreshold', 'MotionUseExcludeRegions', 'PrivacyMaskXml', 'PausePatrollingTimeout', 'ReservedPTZTimeout', 'MulticastEnabled', 'Guid', 'FailoverSettingValues'
         $recordingStorage = @{}
         Get-VmsRecordingServer -Name $Settings.RecordingServer | Get-VmsStorage | ForEach-Object {
             $recordingStorage[$_.Name] = $_


### PR DESCRIPTION
The `FailoverSetting` and `FailoverSettingValues` properties were added to strongly-typed ConfigurationApi devices in 2025 R1. The FailoverSettingValues property is a `ValueTypeInfos` dictionary with the display names and values for the underlying `FailoverSetting` enum, and it was being exported to a column in the Camera/Microphone/Speaker/Metadata worksheets.

This PR adds the `FailoverSettingValues` property name to the list of `$excludedProperties` so that the column isn't created, and it also ensures the column is ignored during import in case an import is performed using an export created between module versions 25.1.3 and 25.2.6.