### PR TITLE
Fix/alarm definition commands

### DIFF
--- a/MilestonePSTools/Public/Alarms/New-VmsAlarmDefinition.ps1
+++ b/MilestonePSTools/Public/Alarms/New-VmsAlarmDefinition.ps1
@@ -42,15 +42,17 @@ function New-VmsAlarmDefinition {
 
         [Parameter()]
         [string]
-        $TimeProfile,
+        $TimeProfile = 'Always',
 
         # UDEs and Inputs
         [Parameter()]
+        [MipItemToPathTransformation('InputEvent', 'UserDefinedEvent')]
         [string[]]
         $EnabledBy,
         
         # UDEs and Inputs
         [Parameter()]
+        [MipItemToPathTransformation('InputEvent', 'UserDefinedEvent')]
         [string[]]
         $DisabledBy,
 
@@ -96,7 +98,7 @@ function New-VmsAlarmDefinition {
         [string[]]
         $EventsToTrigger
     )
-    
+
     begin {
         Assert-VmsRequirementsMet
         $sources = [system.collections.generic.list[string]]::new()
@@ -145,14 +147,22 @@ function New-VmsAlarmDefinition {
             return
         }
 
-        # TODO: Use switch on parametersetname to determine enablerule
-        if ($PSCmdlet.MyInvocation.BoundParameters.ContainsKey('TimeProfile')) {
+        if ($EnabledBy.Count) {
+            if ($DisabledBy.Count -eq 0) {
+                Write-Error "When configuring an alarm definition to be active when an event is triggered using EnabledBy, you must also provide a value for DisabledBy."
+                return
+            }
+            $def.EnableEventList = $EnabledBy -join ','
+            $def.DisableEventList = $DisabledBy -join ','
+            $def.EnableRule = 2
+        } else {
             $timeProfiles = @{
                 'Always' = 'TimeProfile[00000000-0000-0000-0000-000000000000]'
             }
             (Get-VmsManagementServer).TimeProfileFolder.TimeProfiles | ForEach-Object {
                 if ($null -eq $_) { return }
                 $timeProfiles[$_.Name] = $_.Path
+                $timeProfiles[$_.Path] = $_.Path
             }
 
             if (!$timeProfiles.ContainsKey($TimeProfile)) {
@@ -160,13 +170,11 @@ function New-VmsAlarmDefinition {
                 return
             }
             $def.TimeProfile = $timeProfiles[$TimeProfile]
-            $def.EnableRule = 1
-        }
-
-        if ($PSCmdlet.ParameterSetName -eq 'EventTriggered') {
-            $def.EnableEventList = $EnabledBy -join ','
-            $def.DisableEventList = $DisabledBy -join ','
-            $def.EnableRule = 2
+            if ($def.TimeProfile -eq $timeProfiles.Always) {
+                $def.EnableRule = 0
+            } else {
+                $def.EnableRule = 1
+            }
         }
 
         if ($PSCmdlet.MyInvocation.BoundParameters.ContainsKey('Priority')) {

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -22,6 +22,9 @@ hide:
 - Added `FailoverSettingValues` to the list of ignored properties when using `Export-VmsHardware` to create an
   Excel export. This caused a non-terminating error when later importing the Excel file using `Import-VmsHardware`.
 - Fixed a non-terminating error with `Remove-VmsArchiveStorage` when using the `ByStorage` parameter set.
+- Fixed [Issue #199](https://github.com/MilestoneSystemsInc/PowerShellSamples/issues/199) related to the
+  `New-VmsAlarmDefinition` and `Set-VmsAlarmDefinition` commands where the `EnabledBy` and `DisabledBy` parameters
+  would not work, and the `SmartMap` or `RelatedMap` parameter had to be present even when not changing the setting.
 
 ## [25.2.6] 2025-06-18
 

--- a/docs/commands/en-US/New-VmsAlarmDefinition.md
+++ b/docs/commands/en-US/New-VmsAlarmDefinition.md
@@ -13,21 +13,12 @@ Creates a new alarm definition.
 
 ## SYNTAX
 
-### SmartMap
 ```
-New-VmsAlarmDefinition -Name <String> -EventTypeGroup <String> -EventType <String> -Source <String[]>
- [-RelatedCameras <Camera[]>] [-TimeProfile <String>] [-EnabledBy <String[]>] [-DisabledBy <String[]>]
- [-Instructions <String>] [-Priority <String>] [-Category <String>] [-AssignableToAdmins] [-Timeout <TimeSpan>]
- [-TimeoutAction <String[]>] [-SmartMap] [-Owner <String>] [-EventsToTrigger <String[]>] [<CommonParameters>]
-```
-
-### RelatedMap
-```
-New-VmsAlarmDefinition -Name <String> -EventTypeGroup <String> -EventType <String> -Source <String[]>
- [-RelatedCameras <Camera[]>] [-TimeProfile <String>] [-EnabledBy <String[]>] [-DisabledBy <String[]>]
- [-Instructions <String>] [-Priority <String>] [-Category <String>] [-AssignableToAdmins] [-Timeout <TimeSpan>]
- [-TimeoutAction <String[]>] [-RelatedMap <String>] [-Owner <String>] [-EventsToTrigger <String[]>]
- [<CommonParameters>]
+New-VmsAlarmDefinition [-Name] <String> [-EventTypeGroup] <String> [-EventType] <String> [-Source] <String[]>
+ [[-RelatedCameras] <Camera[]>] [[-TimeProfile] <String>] [[-EnabledBy] <String[]>] [[-DisabledBy] <String[]>]
+ [[-Instructions] <String>] [[-Priority] <String>] [[-Category] <String>] [-AssignableToAdmins]
+ [[-Timeout] <TimeSpan>] [[-TimeoutAction] <String[]>] [-SmartMap] [[-RelatedMap] <String>] [[-Owner] <String>]
+ [[-EventsToTrigger] <String[]>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -127,15 +118,18 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: Named
+Position: 10
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -DisabledBy
-Specifies which event(s) can disable the alarm definition, preventing alarms from being created when the source event is
-triggered.
+Specifies which event(s) can disable the alarm definition, disabling alarms from being created from the alarm
+definition after the source event(s) are triggered. Only device inputs (InputEvent) and user-defined events are allowed
+for enabling/disabling an alarm definition. You may supply an object returned by `Get-VmsInput`, or
+`Get-UserDefinedEvent`, or you can provide the configuration api path for an input or user-defined event which use
+the format "InputEvent[1aefd587-1d66-4213-b424-161d3992de45]", or "UserDefinedEvent[602242bc-2a01-4f4f-a965-118467166792]".
 
 ```yaml
 Type: String[]
@@ -143,14 +137,18 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: Named
+Position: 7
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -EnabledBy
-Specifies which event(s) can enable the alarm definition, allowing alarms to be created when the source event is triggered.
+Specifies which event(s) can enable the alarm definition, allowing alarms to be created from the alarm definition
+only after the source event(s) are triggered. Only device inputs (InputEvent) and user-defined events are allowed
+for enabling/disabling an alarm definition. You may supply an object returned by `Get-VmsInput`, or
+`Get-UserDefinedEvent`, or you can provide the configuration api path for an input or user-defined event which use
+the format "InputEvent[1aefd587-1d66-4213-b424-161d3992de45]", or "UserDefinedEvent[602242bc-2a01-4f4f-a965-118467166792]".
 
 ```yaml
 Type: String[]
@@ -158,7 +156,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: Named
+Position: 6
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -173,7 +171,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: Named
+Position: 15
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -189,7 +187,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: Named
+Position: 2
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -205,7 +203,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: Named
+Position: 1
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -220,7 +218,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: Named
+Position: 8
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -235,7 +233,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: Named
+Position: 0
 Default value: None
 Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
@@ -251,7 +249,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: Named
+Position: 14
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -266,7 +264,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: Named
+Position: 9
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -281,7 +279,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: Named
+Position: 4
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -293,11 +291,11 @@ and not "Smart Maps". You can get a list of map names the event server will acce
 
 ```yaml
 Type: String
-Parameter Sets: RelatedMap
+Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: Named
+Position: 13
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -308,7 +306,7 @@ Specifies that alarms created from this alarm definition should show a "Smart Ma
 
 ```yaml
 Type: SwitchParameter
-Parameter Sets: SmartMap
+Parameter Sets: (All)
 Aliases:
 
 Required: False
@@ -330,7 +328,7 @@ Parameter Sets: (All)
 Aliases: Path
 
 Required: True
-Position: Named
+Position: 3
 Default value: None
 Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
@@ -346,7 +344,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: Named
+Position: 11
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -361,7 +359,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: Named
+Position: 12
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -376,7 +374,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: Named
+Position: 5
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/commands/en-US/Set-VmsAlarmDefinition.md
+++ b/docs/commands/en-US/Set-VmsAlarmDefinition.md
@@ -12,22 +12,12 @@ Sets one or more properties of an existing alarm definition.
 
 ## SYNTAX
 
-### SmartMap
 ```
 Set-VmsAlarmDefinition [-AlarmDefinition] <AlarmDefinition[]> [-Name <String>] [-Source <String[]>]
  [-RelatedCameras <String[]>] [-TimeProfile <String>] [-EnabledBy <String[]>] [-DisabledBy <String[]>]
  [-Instructions <String>] [-Priority <String>] [-Category <String>] [-AssignableToAdmins] [-Timeout <TimeSpan>]
- [-TimeoutAction <String[]>] [-SmartMap] [-Owner <String>] [-EventsToTrigger <String[]>] [-PassThru] [-WhatIf]
- [-Confirm] [<CommonParameters>]
-```
-
-### RelatedMap
-```
-Set-VmsAlarmDefinition [-AlarmDefinition] <AlarmDefinition[]> [-Name <String>] [-Source <String[]>]
- [-RelatedCameras <String[]>] [-TimeProfile <String>] [-EnabledBy <String[]>] [-DisabledBy <String[]>]
- [-Instructions <String>] [-Priority <String>] [-Category <String>] [-AssignableToAdmins] [-Timeout <TimeSpan>]
- [-TimeoutAction <String[]>] [-RelatedMap <String>] [-Owner <String>] [-EventsToTrigger <String[]>] [-PassThru]
- [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-TimeoutAction <String[]>] [-SmartMap] [-RelatedMap <String>] [-Owner <String>] [-EventsToTrigger <String[]>]
+ [-PassThru] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -98,8 +88,11 @@ Accept wildcard characters: False
 ```
 
 ### -DisabledBy
-Specifies which event(s) can disable the alarm definition, preventing alarms from being created when the source event is
-triggered.
+Specifies which event(s) can disable the alarm definition, disabling alarms from being created from the alarm
+definition after the source event(s) are triggered. Only device inputs (InputEvent) and user-defined events are allowed
+for enabling/disabling an alarm definition. You may supply an object returned by `Get-VmsInput`, or
+`Get-UserDefinedEvent`, or you can provide the configuration api path for an input or user-defined event which use
+the format "InputEvent[1aefd587-1d66-4213-b424-161d3992de45]", or "UserDefinedEvent[602242bc-2a01-4f4f-a965-118467166792]".
 
 ```yaml
 Type: String[]
@@ -114,7 +107,11 @@ Accept wildcard characters: False
 ```
 
 ### -EnabledBy
-Specifies which event(s) can enable the alarm definition, allowing alarms to be created when the source event is triggered.
+Specifies which event(s) can enable the alarm definition, allowing alarms to be created from the alarm definition
+only after the source event(s) are triggered. Only device inputs (InputEvent) and user-defined events are allowed
+for enabling/disabling an alarm definition. You may supply an object returned by `Get-VmsInput`, or
+`Get-UserDefinedEvent`, or you can provide the configuration api path for an input or user-defined event which use
+the format "InputEvent[1aefd587-1d66-4213-b424-161d3992de45]", or "UserDefinedEvent[602242bc-2a01-4f4f-a965-118467166792]".
 
 ```yaml
 Type: String[]
@@ -236,11 +233,12 @@ Accept wildcard characters: False
 
 ### -RelatedMap
 Specifies the name of a map to relate to alarms created from this alarm definition. Note that this field works with "Maps"
-and not "Smart Maps". You can get a list of map names the event server will accept by running `(Get-VmsManagementServer).AlarmDefinitionFolder.AddAlarmDefinition().RelatedMapValues.Keys`.
+and not "Smart Maps". You can get a list of map names the event server will accept by running
+`(Get-VmsManagementServer).AlarmDefinitionFolder.AddAlarmDefinition().RelatedMapValues.Keys`.
 
 ```yaml
 Type: String
-Parameter Sets: RelatedMap
+Parameter Sets: (All)
 Aliases:
 
 Required: False
@@ -251,11 +249,13 @@ Accept wildcard characters: False
 ```
 
 ### -SmartMap
-Specifies that alarms created from this alarm definition should show a "Smart Map" which displays objects using their GPS coordinates.
+Deprecated: Specifies that alarms created from this alarm definition should show a "Smart Map" which displays
+objects using their GPS coordinates. This is the default behavior so this parameter is not needed. If you want to
+relate alarms to a "legacy" map, provide the name of the map using the RelatedMap parameter.
 
 ```yaml
 Type: SwitchParameter
-Parameter Sets: SmartMap
+Parameter Sets: (All)
 Aliases:
 
 Required: False

--- a/src/MilestonePSTools/MilestonePSTools.csproj
+++ b/src/MilestonePSTools/MilestonePSTools.csproj
@@ -143,6 +143,7 @@
     <Compile Include="Utility\KindArgumentCompleter.cs" />
     <Compile Include="Utility\KindNameTransformAttribute.cs" />
     <Compile Include="Utility\MipItemNameArgumentCompleter.cs" />
+    <Compile Include="Utility\MipItemToPathTransformationAttribute.cs" />
     <Compile Include="Utility\AviCodecArgumentCompleter.cs" />
     <Compile Include="Lpr\NewLprMatchListCommand.cs" />
     <Compile Include="Lpr\GetLprEventCommand.cs" />

--- a/src/MilestonePSTools/Utility/MipItemToPathTransformationAttribute.cs
+++ b/src/MilestonePSTools/Utility/MipItemToPathTransformationAttribute.cs
@@ -1,0 +1,91 @@
+// Copyright 2025 Milestone Systems A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+using System.Management.Automation;
+using VideoOS.Platform.ConfigurationItems;
+using VideoOS.Platform.Proxy.ConfigApi;
+
+namespace MilestonePSTools.Utility
+{
+    public class MipItemToPathTransformationAttribute : ArgumentTransformationAttribute
+    {
+        private readonly string[] _itemTypes;
+
+        public MipItemToPathTransformationAttribute()
+        {
+            _itemTypes = new string[] { };
+        }
+
+        public MipItemToPathTransformationAttribute(params string[] itemTypes)
+        {
+            _itemTypes = itemTypes;
+        }
+
+        public override object Transform(EngineIntrinsics engineIntrinsics, object inputData)
+        {
+            if (inputData == null) return string.Empty;
+            if (inputData is IEnumerable<object> objArray)
+            {
+                return objArray.Select(obj =>
+                {
+                    var baseObject = obj is PSObject psObject ? psObject.BaseObject : obj;
+                    if (baseObject is IConfigurationItem item)
+                    {
+                        ValidateItemType(item.Path);
+                        return item.Path;
+                    }
+                    ValidateItemType(baseObject.ToString());
+                    return baseObject.ToString();
+                });
+            }
+            else
+            {
+                var baseObject = inputData is PSObject psObject ? psObject.BaseObject : inputData;
+                if (baseObject is IConfigurationItem item)
+                {
+                    ValidateItemType(item.Path);
+                    return item.Path;
+                }
+                ValidateItemType(baseObject.ToString());
+                return baseObject.ToString();
+            }
+        }
+
+        private void ValidateItemType(string path)
+        {
+            if (_itemTypes.Length == 0) return;
+            try
+            {
+                var configItemPath = new ConfigurationItemPath(path);
+                if (!_itemTypes.Contains(configItemPath.ItemType, StringComparer.OrdinalIgnoreCase))
+                {
+                    var message = $"Expected an item of type {string.Join(", or ", _itemTypes)}, but received an item of type {configItemPath.ItemType} instead.";
+                    throw new ArgumentTransformationMetadataException(
+                        message,
+                        new PSInvalidCastException(message));
+                }
+            }
+            catch (VideoOS.Platform.ArgumentMIPException mipException)
+            {
+                var message = $"The string '{path}' is not a valid configuration item path for an XProtect VMS configuration item.";
+                throw new ArgumentTransformationMetadataException(
+                    message, new PSInvalidCastException(message, mipException));
+            }
+        }
+    }
+}

--- a/tests/MilestonePSTools/read-write/AlarmDefinitions/AlarmDefinitions.integration.ps1
+++ b/tests/MilestonePSTools/read-write/AlarmDefinitions/AlarmDefinitions.integration.ps1
@@ -1,0 +1,109 @@
+Context 'AlarmDefinitions' -Skip:($script:SkipReadWriteTests) {
+    BeforeAll {
+        $script:ExistingAlarms = Get-VmsAlarmDefinition
+        $ms = Get-VmsManagementServer
+        $ms.TimeProfileFolder.TimeProfiles | Where-Object Name -Match '^Test Time Profile' | ForEach-Object {
+            $null = $ms.TimeProfileFolder.RemoveTimeProfile($_.Path)
+        }
+        $ms.TimeProfileFolder.ClearChildrenCache()
+        Get-UserDefinedEvent | Where-Object Name -Match 'abledBy UDE' | Remove-UserDefinedEvent
+
+        $invokeInfo = (Get-VmsManagementServer).TimeProfileFolder.AddTimeProfile()
+        $invokeInfo.Name = 'Test Time Profile'
+        $invokeResult = $invokeInfo.ExecuteDefault()
+        $script:TimeProfile = (Get-VmsManagementServer).TimeProfileFolder.TimeProfiles | Where-Object Path -EQ $invokeResult.Path
+        $script:EnabledByUDE = Add-UserDefinedEvent -Name 'EnabledBy UDE'
+        $script:DisabledByUDE = Add-UserDefinedEvent -Name 'DisabledBy UDE'
+    }
+
+    Describe 'New-VmsAlarmDefinition' {
+        It '<name>' -ForEach @(
+            @{
+                Name   = 'Simple parameters'
+                Params = @{
+                    Name           = "New Alarm $([datetime]::now.Ticks)"
+                    EventTypeGroup = 'Device Events'
+                    EventType      = 'Motion Started Driver'
+                    Source         = 'AllCameras'
+                }
+            },
+            @{
+                Name   = 'Explicit TimeProfile - Always'
+                Params = @{
+                    Name           = "New Alarm $([datetime]::now.Ticks)"
+                    EventTypeGroup = 'Device Events'
+                    EventType      = 'Motion Started Driver'
+                    Source         = 'AllCameras'
+                    TimeProfile    = 'Always'
+                }
+            },
+            @{
+                Name   = 'Explicit TimeProfile - User Defined'
+                Params = @{
+                    Name           = "New Alarm $([datetime]::now.Ticks)"
+                    EventTypeGroup = 'Device Events'
+                    EventType      = 'Motion Started Driver'
+                    Source         = 'AllCameras'
+                    TimeProfile    = 'Test Time Profile'
+                }
+            },
+            @{
+                Name   = 'EnabledBy User-defined Event'
+                Params = @{
+                    Name           = "New Alarm $([datetime]::now.Ticks)"
+                    EventTypeGroup = 'Device Events'
+                    EventType      = 'Motion Started Driver'
+                    Source         = 'AllCameras'
+                    EnabledBy      = 'EnabledBy UDE'
+                    DisabledBy     = 'DisabledBy UDE'
+                }
+            }
+        ) {
+            $Params.Name = "$Name $([datetime]::now.Ticks)"
+            if ($Params.EnabledBy) {
+                $Params.EnabledBy = Get-UserDefinedEvent -Name $Params.EnabledBy
+                $Params.DisabledBy = Get-UserDefinedEvent -Name $Params.DisabledBy
+            }
+            $def = New-VmsAlarmDefinition @Params
+            $def | Should -BeOfType -ExpectedType ([VideoOS.Platform.ConfigurationItems.AlarmDefinition])
+            $def.Name | Should -BeExactly $Params.Name
+        }
+    }
+
+    Describe 'Set-VmsAlarmDefinition' {
+        BeforeAll {
+            $alarmParams = @{
+                Name           = "Set-VmsAlarmDefinition $([datetime]::now.Ticks)"
+                EventTypeGroup = 'Device Events'
+                EventType      = 'Motion Started Driver'
+                Source         = 'AllCameras'
+                ErrorAction    = 'Stop'
+            }
+            $script:alarm = New-VmsAlarmDefinition @alarmParams
+
+        }
+
+        It 'Can change name' {
+            $newName = "New Alarm Definition Name $([datetime]::now.Ticks)"
+            $script:alarm | Set-VmsAlarmDefinition -Name $newName
+            (Get-VmsManagementServer).AlarmDefinitionFolder.ClearChildrenCache()
+            (Get-VmsAlarmDefinition -Name $newName) | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Can change TimeProfile' {
+            $script:alarm | Set-VmsAlarmDefinition -TimeProfile 'Test Time Profile' -ErrorAction Stop
+            (Get-VmsManagementServer).AlarmDefinitionFolder.ClearChildrenCache()
+            (Get-VmsAlarmDefinition -Name $script:alarm.Name).TimeProfile | Should -Be $script:TimeProfile.Path
+        }
+    }
+
+    Describe 'Remove-VmsAlarmDefinition' {
+        It 'Can remove alarm definitions' {
+            (Get-VmsManagementServer).AlarmDefinitionFolder.ClearChildrenCache()
+            $alarms = Get-VmsAlarmDefinition
+            $alarms | Where-Object Path -NotIn $script:ExistingAlarms.Path | Remove-VmsAlarmDefinition -Confirm:$false
+            (Get-VmsManagementServer).AlarmDefinitionFolder.ClearChildrenCache()
+            $alarms.Count | Should -BeGreaterThan (Get-VmsAlarmDefinition).Count
+        }
+    }
+}


### PR DESCRIPTION
This PR solves the problems described in [Issue 199](https://github.com/MilestoneSystemsInc/PowerShellSamples/issues/199). Briefly, the `New-VmsAlarmDefinition` and `Set-VmsAlarmDefinition` commands might throw a parameter binding exception error, or fail to change the settings related to the `TimeProfile` or `EnabledBy` and `DisabledBy` parameters.

Some basic end-to-end tests have been added for the New, Set, and `Remove-VmsAlarmDefinition` cmdlets. The integration tests are still not yet executed as a part of the CI/CD pipeline but they passed when run locally.