### PR TITLE
Add UI owner handle

### DIFF
--- a/MilestonePSTools/Private/DialogOwnerHelpers.ps1
+++ b/MilestonePSTools/Private/DialogOwnerHelpers.ps1
@@ -1,0 +1,65 @@
+# Copyright 2025 Milestone Systems A/S
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+function Invoke-WithDialogOwner {
+    [CmdletBinding()]
+    param(
+        [IntPtr] $Handle = [IntPtr]::Zero,
+        [Parameter(Mandatory)][ScriptBlock] $ScriptBlock
+    )
+
+    Add-Type -AssemblyName System.Windows.Forms | Out-Null
+
+    $owner = $null
+    try {
+        if ($Handle -eq [IntPtr]::Zero -and $global:UiOwnerHandle) {
+            $Handle = [IntPtr]$global:UiOwnerHandle
+        }
+
+        if ($Handle -ne [IntPtr]::Zero) {
+            $owner = New-Object System.Windows.Forms.NativeWindow
+            $owner.AssignHandle($Handle)
+        }
+
+        return & $ScriptBlock $owner
+    }
+    finally {
+        if ($owner) {
+            $owner.ReleaseHandle()
+        }
+    }
+}
+
+function Invoke-WithWpfDialogOwner {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][System.Windows.Window] $Window,
+        [IntPtr] $Handle = [IntPtr]::Zero,
+        [Parameter(Mandatory)][ScriptBlock] $ScriptBlock
+    )
+
+    Add-Type -AssemblyName PresentationFramework | Out-Null
+
+    $dialogOwnerHandle = $Handle
+    if ($dialogOwnerHandle -eq [IntPtr]::Zero -and $global:UiOwnerHandle) {
+        $dialogOwnerHandle = [IntPtr]$global:UiOwnerHandle
+    }
+
+    if ($dialogOwnerHandle -ne [IntPtr]::Zero) {
+        $interop = [System.Windows.Interop.WindowInteropHelper]::new($Window)
+        $interop.Owner = $dialogOwnerHandle
+    }
+
+    return & $ScriptBlock $Window
+}

--- a/MilestonePSTools/Private/DialogOwnerHelpers.ps1
+++ b/MilestonePSTools/Private/DialogOwnerHelpers.ps1
@@ -16,12 +16,15 @@ function Invoke-WithDialogOwner {
     [CmdletBinding()]
     param(
         [IntPtr] $Handle = [IntPtr]::Zero,
+        [switch] $TopMostFallback,
         [Parameter(Mandatory)][ScriptBlock] $ScriptBlock
     )
 
     Add-Type -AssemblyName System.Windows.Forms | Out-Null
 
     $owner = $null
+    $topMostOwnerForm = $null
+    $dialogOwner = $null
     try {
         if ($Handle -eq [IntPtr]::Zero -and $global:UiOwnerHandle) {
             $Handle = [IntPtr]$global:UiOwnerHandle
@@ -30,13 +33,28 @@ function Invoke-WithDialogOwner {
         if ($Handle -ne [IntPtr]::Zero) {
             $owner = New-Object System.Windows.Forms.NativeWindow
             $owner.AssignHandle($Handle)
+        } elseif ($TopMostFallback) {
+            $topMostOwnerForm = New-Object System.Windows.Forms.Form
+            $topMostOwnerForm.TopMost = $true
+            $topMostOwnerForm.ShowInTaskbar = $false
+            $topMostOwnerForm.StartPosition = [System.Windows.Forms.FormStartPosition]::Manual
+            $topMostOwnerForm.Size = [System.Drawing.Size]::new(1, 1)
         }
 
-        return & $ScriptBlock $owner
+        if ($owner) {
+            $dialogOwner = $owner
+        } elseif ($topMostOwnerForm) {
+            $dialogOwner = $topMostOwnerForm
+        }
+
+        return & $ScriptBlock $dialogOwner
     }
     finally {
         if ($owner) {
             $owner.ReleaseHandle()
+        }
+        if ($topMostOwnerForm) {
+            $topMostOwnerForm.Dispose()
         }
     }
 }
@@ -46,6 +64,7 @@ function Invoke-WithWpfDialogOwner {
     param(
         [Parameter(Mandatory)][System.Windows.Window] $Window,
         [IntPtr] $Handle = [IntPtr]::Zero,
+        [switch] $TopMostFallback,
         [Parameter(Mandatory)][ScriptBlock] $ScriptBlock
     )
 
@@ -59,6 +78,8 @@ function Invoke-WithWpfDialogOwner {
     if ($dialogOwnerHandle -ne [IntPtr]::Zero) {
         $interop = [System.Windows.Interop.WindowInteropHelper]::new($Window)
         $interop.Owner = $dialogOwnerHandle
+    } elseif ($TopMostFallback) {
+        $Window.Topmost = $true
     }
 
     return & $ScriptBlock $Window

--- a/MilestonePSTools/Private/Find-XProtectDeviceDialog.ps1
+++ b/MilestonePSTools/Private/Find-XProtectDeviceDialog.ps1
@@ -241,7 +241,7 @@ function Find-XProtectDeviceDialog {
                 $var_lblPropertyValueBlank.Visibility = "Hidden"
             })
 
-        Invoke-WithWpfDialogOwner -Window $window -Handle $OwnerHandle -ScriptBlock {
+        Invoke-WithWpfDialogOwner -Window $window -Handle $OwnerHandle -TopMostFallback -ScriptBlock {
             param($dialogWindow)
             $null = $dialogWindow.ShowDialog()
         }

--- a/MilestonePSTools/Private/Find-XProtectDeviceDialog.ps1
+++ b/MilestonePSTools/Private/Find-XProtectDeviceDialog.ps1
@@ -15,7 +15,10 @@
 function Find-XProtectDeviceDialog {
     [CmdletBinding()]
     [RequiresInteractiveSession()]
-    param ()
+    param (
+        [IntPtr]
+        $OwnerHandle = [IntPtr]::Zero
+    )
 
     begin {
         Assert-VmsRequirementsMet
@@ -201,7 +204,7 @@ function Find-XProtectDeviceDialog {
                 $saveDialog.Title = "Save As CSV"
                 $saveDialog.Filter = "Comma delimited (*.csv)|*.csv"
 
-                $saveAs = $saveDialog.ShowDialog()
+                $saveAs = $saveDialog.ShowDialog($window)
 
                 if ($saveAs -eq $true) {
                     $script:searchResults | Export-Csv -Path $saveDialog.FileName -NoTypeInformation
@@ -238,7 +241,10 @@ function Find-XProtectDeviceDialog {
                 $var_lblPropertyValueBlank.Visibility = "Hidden"
             })
 
-        $null = $window.ShowDialog()
+        Invoke-WithWpfDialogOwner -Window $window -Handle $OwnerHandle -ScriptBlock {
+            param($dialogWindow)
+            $null = $dialogWindow.ShowDialog()
+        }
     }
 }
 
@@ -311,4 +317,3 @@ function Find-XProtectDeviceSearch {
         return $results
     }
 }
-

--- a/MilestonePSTools/Private/ImportVmsHardwareExcelFunctions.ps1
+++ b/MilestonePSTools/Private/ImportVmsHardwareExcelFunctions.ps1
@@ -53,20 +53,9 @@ function Show-FileDialog {
         }
 
         try {
-            $owner = $null
-            $dialogResult = Invoke-WithDialogOwner -Handle $OwnerHandle -ScriptBlock {
+            $dialogResult = Invoke-WithDialogOwner -Handle $OwnerHandle -TopMostFallback -ScriptBlock {
                 param($ownerHandle)
-                if ($ownerHandle) {
-                    return $dialog.ShowDialog($ownerHandle)
-                }
-                $owner = [form]@{
-                    TopMost = $true
-                }
-                try {
-                    return $dialog.ShowDialog($owner)
-                } finally {
-                    $owner.Dispose()
-                }
+                return $dialog.ShowDialog($ownerHandle)
             }
 
             if ($dialogResult -eq 'OK') {

--- a/MilestonePSTools/Public/Find-XProtectDevice.ps1
+++ b/MilestonePSTools/Public/Find-XProtectDevice.ps1
@@ -54,7 +54,11 @@ function Find-XProtectDevice {
 
         [Parameter(ParameterSetName = 'ShowDialog')]
         [switch]
-        $ShowDialog
+        $ShowDialog,
+
+        [Parameter(ParameterSetName = 'ShowDialog')]
+        [IntPtr]
+        $OwnerHandle = [IntPtr]::Zero
     )
 
     begin {
@@ -63,7 +67,7 @@ function Find-XProtectDevice {
 
     process {
         if ($ShowDialog) {
-            Find-XProtectDeviceDialog
+            Find-XProtectDeviceDialog -OwnerHandle $OwnerHandle
             return
         }
         if ($MyInvocation.BoundParameters.ContainsKey('Address')) {
@@ -107,4 +111,3 @@ function Find-XProtectDevice {
         }
     }
 }
-

--- a/MilestonePSTools/Public/Tools/Select-VideoOSItem.ps1
+++ b/MilestonePSTools/Public/Tools/Select-VideoOSItem.ps1
@@ -72,12 +72,11 @@ function Select-VideoOSItem {
         $form.ServerTabVisable = -not $HideServerTab
         $form.Icon = [System.Drawing.Icon]::FromHandle([VideoOS.Platform.UI.Util]::ImageList.Images[[VideoOS.Platform.UI.Util]::SDK_GeneralIx].GetHicon())
         $form.Text = $Title
-        $form.TopMost = $true
         $form.StartPosition = [System.Windows.Forms.FormStartPosition]::CenterScreen
         $form.BringToFront()
         $form.Activate()
 
-        $dialogResult = Invoke-WithDialogOwner -Handle $OwnerHandle -ScriptBlock {
+        $dialogResult = Invoke-WithDialogOwner -Handle $OwnerHandle -TopMostFallback -ScriptBlock {
             param($owner)
             $form.ShowDialog($owner)
         }

--- a/MilestonePSTools/Public/Tools/Select-VideoOSItem.ps1
+++ b/MilestonePSTools/Public/Tools/Select-VideoOSItem.ps1
@@ -49,7 +49,10 @@ function Select-VideoOSItem {
         $HideGroupsTab,
         [Parameter()]
         [switch]
-        $HideServerTab
+        $HideServerTab,
+        [Parameter()]
+        [IntPtr]
+        $OwnerHandle = [IntPtr]::Zero
     )
 
     begin {
@@ -74,7 +77,12 @@ function Select-VideoOSItem {
         $form.BringToFront()
         $form.Activate()
 
-        if ($form.ShowDialog() -eq [System.Windows.Forms.DialogResult]::OK) {
+        $dialogResult = Invoke-WithDialogOwner -Handle $OwnerHandle -ScriptBlock {
+            param($owner)
+            $form.ShowDialog($owner)
+        }
+
+        if ($dialogResult -eq [System.Windows.Forms.DialogResult]::OK) {
             if ($FlattenOutput) {
                 Write-Output $form.ItemsSelectedFlattened
             }
@@ -84,4 +92,3 @@ function Select-VideoOSItem {
         }
     }
 }
-

--- a/docs/commands/en-US/Find-XProtectDevice.md
+++ b/docs/commands/en-US/Find-XProtectDevice.md
@@ -15,7 +15,8 @@ Finds devices and provides the names of the parent hardware and recording server
 
 ```
 Find-XProtectDevice [-ItemType <String[]>] [-Name <String>] [-Address <String>] [-MacAddress <String>]
- [-EnableFilter <String>] [-Properties <Hashtable>] [-ShowDialog] [<CommonParameters>]
+ [-EnableFilter <String>] [-Properties <Hashtable>] [-ShowDialog] [[-OwnerHandle] <IntPtr>]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -160,6 +161,22 @@ Aliases:
 Required: False
 Position: Named
 Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -OwnerHandle
+
+Specifies an optional UI owner window handle when using -ShowDialog so the dialog is modal to an existing GUI window.
+
+```yaml
+Type: IntPtr
+Parameter Sets: ShowDialog
+Aliases:
+
+Required: False
+Position: Named
+Default value: 0
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/docs/commands/en-US/Select-VideoOSItem.md
+++ b/docs/commands/en-US/Select-VideoOSItem.md
@@ -16,7 +16,7 @@ Offers a UI dialog for selecting items, similar to the item selection interface 
 ```
 Select-VideoOSItem [[-Title] <String>] [[-Kind] <Guid[]>] [[-Category] <Category[]>] [-SingleSelect]
  [-AllowFolders] [-AllowServers] [-KindUserSelectable] [-CategoryUserSelectable] [-FlattenOutput]
- [-HideGroupsTab] [-HideServerTab] [<CommonParameters>]
+ [-HideGroupsTab] [-HideServerTab] [[-OwnerHandle] <IntPtr>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -163,6 +163,22 @@ Aliases:
 Required: False
 Position: Named
 Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -OwnerHandle
+
+Specifies an optional UI owner window handle to make the dialog modal to an existing GUI window.
+
+```yaml
+Type: IntPtr
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: 0
 Accept pipeline input: False
 Accept wildcard characters: False
 ```


### PR DESCRIPTION
## Description

This adds the concept of UI owner handle so GUIs using MilestonePSTools can do proper modals.
It also unify this using helpers so the `.TopMost` fallbacks are handled centrally instead of at various places.

## Motivation and Context

I'm using MilestonePSTools from a WPF app and my other UI helpers use this UI owner handle pattern so my dialogs are modal to the main window.

## How Has This Been Tested?

Untested of course 🤣 

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

