### PR TITLE
ci: Bump azuresigntool to 7.0.1

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -10,7 +10,7 @@
       "rollForward": false
     },
     "azuresigntool": {
-      "version": "4.0.1",
+      "version": "7.0.1",
       "commands": [
         "azuresigntool"
       ],


### PR DESCRIPTION
Bump azuresigntool from 4.0.1 to 7.0.1 after the Publish workflow failed