### PR TITLE
Fixed ImportHardwareCsv issue where invalid Recording Server throws driver error

### DIFF
--- a/MilestonePSTools/Private/ValidateHardwareCsvRows.ps1
+++ b/MilestonePSTools/Private/ValidateHardwareCsvRows.ps1
@@ -129,7 +129,7 @@ function ValidateHardwareCsvRows {
                     'Password' {}
                     'RecordingServer' {
                         if (-not [string]::IsNullOrWhiteSpace($record.RecordingServer) -and -not $recorders.ContainsKey($record.RecordingServer)) {
-                            Write-Error -Message "Invalid RecordingServer value `"$($row.Channel)`" in row $($i + 1)." -Category InvalidData -ErrorId "InvalidValue" -TargetObject $row
+                            Write-Error -Message "Invalid RecordingServer value `"$($row.RecordingServer)`" in row $($i + 1)." -Category InvalidData -ErrorId "InvalidValue" -TargetObject $row
                         }
                     }
                     'DriverNumber' {
@@ -140,7 +140,8 @@ function ValidateHardwareCsvRows {
                         if (-not [int]::TryParse($record.DriverNumber, [ref]$driverNumber)) {
                             Write-Error -Message "Invalid DriverNumber value `"$($row.DriverNumber)`" in row $($i + 1)." -Category InvalidData -ErrorId "InvalidValue" -TargetObject $row
                         }
-                        if (-not [string]::IsNullOrWhiteSpace($record.RecordingServer) -and -not [string]::IsNullOrWhiteSpace($row.DriverNumber) -and -not $driversByRecorder.ContainsKey("$($record.RecordingServer).$($record.DriverNumber)")) {
+                        # Only validate DriverNumber if RecordingServer exists - otherwise the recording server validation will have already thrown an error
+                        if (-not [string]::IsNullOrWhiteSpace($record.RecordingServer) -and $recorders.ContainsKey($record.RecordingServer) -and -not [string]::IsNullOrWhiteSpace($row.DriverNumber) -and -not $driversByRecorder.ContainsKey("$($record.RecordingServer).$($record.DriverNumber)")) {
                             Write-Error -Message "DriverNumber `"$($row.DriverNumber)`" in row $($i + 1) not found on RecordingServer `"$($record.RecordingServer)`". You may need to install a newer device pack version or custom device driver." -Category InvalidData -ErrorId "InvalidValue" -TargetObject $row
                         }
                         $record.DriverNumber = $driverNumber


### PR DESCRIPTION
## Description
When running Import-VmsHardware from a CSV file, if the Recording Server name wasn't valid, it would throw an error related to the driver instead of the Recording Server.

## Related Issue
https://github.com/milestonesys/MilestonePSTools/issues/76

## Motivation and Context
Corrects an incorrect error

## How Has This Been Tested?
I built the module locally and then verified Import-VmsHardware still worked and verified that it threw the appropriate error if the Recording Server name was invalid and if the driver number was invalid.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

