### PR TITLE
Fixed bug (Issue 74) where Get-VmsLprEvent ignored CameraId parameter and would just return all events.

### DIFF
--- a/src/MilestonePSTools/Lpr/GetLprEventCommand.cs
+++ b/src/MilestonePSTools/Lpr/GetLprEventCommand.cs
@@ -64,7 +64,7 @@ namespace MilestonePSTools.Lpr
             }
             if (MyInvocation.BoundParameters.ContainsKey(nameof(CameraId)))
             {
-                conditions.Add(new Condition { Target = Target.CameraId, Operator = Operator.Equals, Value = CameraId });
+                conditions.Add(new Condition { Target = Target.ObjectId, Operator = Operator.Equals, Value = CameraId });
             }
             
             using (var reader = new EventLineReader(Connection.CurrentSite.FQID.ServerId))


### PR DESCRIPTION
## Description
The `Get-VmsLprEvent` cmdlet was not properly filtering results by camera ID. When using the `-CameraId` parameter or piping a camera object, the cmdlet would return all LPR events from all cameras within the specified time range, regardless of which camera ID was provided.

This affected all usage scenarios:
```
$camera | Get-VmsLprEvent
Get-VmsLprEvent -CameraId $camera.Id
Get-VmsLprEvent -CameraId '<any-guid>'
```

Even providing a completely fake/non-existent GUID would still return results, indicating the filter was being completely ignored.

The cmdlet was using `Target.CameraId` when constructing the event filter condition. However, in the Milestone Event Server API, the `Target.ObjectId` field represents the device/camera that generated the event, not `Target.CameraId`.

While CameraId is a valid Target enum value, it is used for alarm-specific filtering rather than general event filtering. As a result, the Milestone API was ignoring the unsupported condition and returning unfiltered results.

This was fixed by changing the filter target from `Target.CameraId` to `Target.ObjectId`

## Related Issue
https://github.com/milestonesys/MilestonePSTools/issues/74

## Motivation and Context
It solves the bug mentioned above.

## How Has This Been Tested?
I built the project and then made sure that events were returned only when piping in a valid camera object or when providing a valid GUID with the `-CameraId` parameter.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.