### PR TITLE
docs: Use official mkdocs-material image

### DIFF
--- a/psakefile.ps1
+++ b/psakefile.ps1
@@ -87,7 +87,7 @@ using namespace VideoOS.Platform.ConfigurationItems
     #     $psake.context.tasks.GenerateMAML.DependsOn = $psake.context.tasks.GenerateMAML.DependsOn | Where-Object { $_ -ne 'GenerateMarkdown' }
     # }
 
-    $script:MkdocsImage = 'ghcr.io/milestonesystemsinc/mkdocs-material-insiders:latest'
+    $script:MkdocsImage = $env:DOCKER_PROXY + 'squidfunk/mkdocs-material:latest'
     $script:EmbeddedModules = @(
         @{
             Name            = 'ImportExcel'


### PR DESCRIPTION
The Material for MkDocs project is no longer under development, and as such, the "insiders" features were merged with the public container image. This PR updates the image we use to build the docs since previously it used an image that is only available under the milestonesystemsinc org.