### PR TITLE
Change IncludeRetentionInfo parameter to exclude Evidence Locks outside of configured retention windows

### DIFF
--- a/MilestonePSTools/Public/Reports/Get-VmsCameraReport.ps1
+++ b/MilestonePSTools/Public/Reports/Get-VmsCameraReport.ps1
@@ -199,7 +199,7 @@ function Get-VmsCameraReport {
                 Write-Verbose 'Fetching evidence locks'
                 $evidenceLockedDeviceIds = [System.Collections.Generic.HashSet[guid]]::new()
                 try {
-                    $evidenceLocks = Get-EvidenceLock -ErrorAction Stop
+                    $evidenceLocks = Get-EvidenceLock -DeviceIds $ids -ErrorAction Stop
                     foreach ($lock in $evidenceLocks) {
                         foreach ($deviceId in $lock.DeviceIds) {
                             $null = $evidenceLockedDeviceIds.Add($deviceId)

--- a/MilestonePSTools/Public/Reports/Get-VmsCameraReport.ps1
+++ b/MilestonePSTools/Public/Reports/Get-VmsCameraReport.ps1
@@ -312,22 +312,21 @@ function Get-VmsCameraReport {
                         param(
                             [guid]$Id,
                             [double]$ConfiguredRetentionDays,
-                            [hashtable]$cache
+                            [bool]$HasPlaybackInfo
                         )
-                        
-                        if (-not $cache.PlaybackInfo.ContainsKey($Id)) {
+
+                        if (-not $HasPlaybackInfo) {
                             return
                         }
 
                         # Use the GetNext method on VideoOS.Platform.Data.RawVideoSource
                         # to find the GOP less than or equal to the configured retention.
                         $now = (Get-Date).ToUniversalTime()
-                        $videoFound = $null
 
                         $item = Get-VmsVideoOSItem -Kind Camera -Id $Id
                         $src = [VideoOS.Platform.Data.RawVideoSource]::new($item)
                         $src.Init()
-                        $videoFound = $src.GetNext($now.AddDays(-$configuredRetentionDays))
+                        $videoFound = $src.GetNext($now.AddDays(-$ConfiguredRetentionDays))
                         if ($null -eq $videoFound -or $null -eq $videoFound.List -or $videoFound.List.Count -lt 1) {
                             return
                         }
@@ -337,7 +336,7 @@ function Get-VmsCameraReport {
                             return
                         }
 
-                        $cache.TrueRetention[$Id] = $gopStart.DateTime
+                        [pscustomobject]@{ Id = $Id; TrueBegin = $gopStart.DateTime }
                     }
 
                     $trueRetentionJobs = @()
@@ -352,7 +351,7 @@ function Get-VmsCameraReport {
                                         $trueRetentionJobs += $jobRunner.AddJob($trueRetentionScriptBlock, @{
                                             Id                      = $camId
                                             ConfiguredRetentionDays = $configuredRetentionDays
-                                            cache                   = $cache
+                                            HasPlaybackInfo         = $cache.PlaybackInfo.ContainsKey($camId)
                                         })
                                     }
                                 }
@@ -363,9 +362,13 @@ function Get-VmsCameraReport {
                     if ($trueRetentionJobs.Count -gt 0) {
                         Write-Verbose 'Receiving results of true retention threadjobs'
                         $jobRunner.Wait($trueRetentionJobs)
-                        $trueRetentionResult = $jobRunner.ReceiveJobs($trueRetentionJobs)
-                        foreach ($e in $trueRetentionResult.Errors) {
-                            Write-Error $e
+                        foreach ($job in $jobRunner.ReceiveJobs($trueRetentionJobs)) {
+                            if ($null -ne $job.Output.Id) {
+                                $cache.TrueRetention[$job.Output.Id] = $job.Output.TrueBegin
+                            }
+                            foreach ($e in $job.Errors) {
+                                Write-Error $e
+                            }
                         }
                     }
                 }

--- a/MilestonePSTools/Public/Reports/Get-VmsCameraReport.ps1
+++ b/MilestonePSTools/Public/Reports/Get-VmsCameraReport.ps1
@@ -522,8 +522,6 @@ function Get-VmsCameraReport {
 
                             }
                             if ($IncludeRetentionInfo) {
-                                $obj.MediaDatabaseBegin           = $cache.PlaybackInfo[$id].Begin
-                                $obj.MediaDatabaseEnd             = $cache.PlaybackInfo[$id].End
                                 $obj.HasEvidenceLock              = $evidenceLockedDeviceIds.Contains($id)
                                 $obj.OldestVideoInRetentionWindow = $null
                                 $obj.ActualRetentionDays          = $null

--- a/MilestonePSTools/Public/Reports/Get-VmsCameraReport.ps1
+++ b/MilestonePSTools/Public/Reports/Get-VmsCameraReport.ps1
@@ -305,8 +305,7 @@ function Get-VmsCameraReport {
                 }
 
                 # For cameras with evidence locks, find the true retention begin by
-                # walking from the configured retention boundary toward the present,
-                # skipping evidence-locked video that would have otherwise been deleted.
+                # using the GetNext method on VideoOS.Platform.Data.RawVideoSource.
                 if ($evidenceLockedDeviceIds.Count -gt 0) {
                     Write-Verbose 'Starting true retention threadjobs for evidence-locked cameras'
                     $trueRetentionScriptBlock = {
@@ -320,22 +319,16 @@ function Get-VmsCameraReport {
                             return
                         }
 
-                        # Start from the configured retention boundary and walk forward
-                        # to find the oldest video within the retention window.
-                        # With the formula StartTime=now-($day+1), EndTime=now-$day,
-                        # we want the first window's StartTime to align with the
-                        # retention boundary (now - ConfiguredRetentionDays).
-                        $day = [math]::Ceiling($ConfiguredRetentionDays) - 1
+                        # Use the GetNext method on VideoOS.Platform.Data.RawVideoSource
+                        # to find the GOP less than or equal to the configured retention.
                         $now = (Get-Date).ToUniversalTime()
                         $videoFound = $null
 
-                        while (-not $videoFound -and $day -ge 0) {
-                            $videoFound = Get-SequenceData -Path "Camera[$Id]" -StartTime $now.AddDays(-$day - 1) -EndTime $now.AddDays(-$day) | Select-Object -First 1
-                            if ($videoFound) {
-                                $cache.TrueRetention[$Id] = $videoFound.EventSequence.StartDateTime
-                            }
-                            $day--
-                        }
+                        $item = Get-VmsVideoOSItem -Kind Camera -Id $Id
+                        $src = [VideoOS.Platform.Data.RawVideoSource]::new($item)
+                        $src.Init()
+                        $videoFound = $src.GetNext($now.AddDays(-$configuredRetentionDays))
+                        $cache.TrueRetention[$Id] = $videoFound.List[0].DateTime
                     }
 
                     $trueRetentionJobs = @()
@@ -524,10 +517,10 @@ function Get-VmsCameraReport {
                                 $obj.MediaDatabaseEnd             = $cache.PlaybackInfo[$id].End
                                 $obj.HasEvidenceLock              = $evidenceLockedDeviceIds.Contains($id)
                                 $obj.OldestVideoInRetentionWindow = $null
-                                $obj.ActualRetentionDays          = [double]0
+                                $obj.ActualRetentionDays          = $null
                                 $obj.MeetsRetentionPolicy         = $null
                                 if ($obj.HasEvidenceLock -and $cache.TrueRetention.ContainsKey($id)) {
-                                    # True retention walk found non-locked video
+                                    # True retention found non-locked video
                                     $trueBegin = $cache.TrueRetention[$id]
                                     $obj.OldestVideoInRetentionWindow = $trueBegin
                                     $obj.ActualRetentionDays = [math]::Round(((Get-Date).ToUniversalTime() - $trueBegin).TotalDays, 2)

--- a/MilestonePSTools/Public/Reports/Get-VmsCameraReport.ps1
+++ b/MilestonePSTools/Public/Reports/Get-VmsCameraReport.ps1
@@ -314,8 +314,8 @@ function Get-VmsCameraReport {
                             [double]$ConfiguredRetentionDays,
                             [hashtable]$cache
                         )
-                        $playbackInfo = $cache.PlaybackInfo[$Id]
-                        if ($null -eq $playbackInfo) {
+                        
+                        if (-not $cache.PlaybackInfo.ContainsKey($Id)) {
                             return
                         }
 

--- a/MilestonePSTools/Public/Reports/Get-VmsCameraReport.ps1
+++ b/MilestonePSTools/Public/Reports/Get-VmsCameraReport.ps1
@@ -522,8 +522,9 @@ function Get-VmsCameraReport {
                                 if ($obj.HasEvidenceLock -and $cache.TrueRetention.ContainsKey($id)) {
                                     # True retention found non-locked video
                                     $trueBegin = $cache.TrueRetention[$id]
+                                    $retentionEnd = if ($null -ne $cache.PlaybackInfo[$id].End) { $cache.PlaybackInfo[$id].End } else { (Get-Date).ToUniversalTime() }
                                     $obj.OldestVideoInRetentionWindow = $trueBegin
-                                    $obj.ActualRetentionDays = [math]::Round(((Get-Date).ToUniversalTime() - $trueBegin).TotalDays, 2)
+                                    $obj.ActualRetentionDays = [math]::Round(($retentionEnd - $trueBegin).TotalDays, 2)
                                 } elseif ($obj.HasEvidenceLock) {
                                     # Evidence locks present but no non-locked video found within the retention window
                                     $obj.OldestVideoInRetentionWindow = $null

--- a/MilestonePSTools/Public/Reports/Get-VmsCameraReport.ps1
+++ b/MilestonePSTools/Public/Reports/Get-VmsCameraReport.ps1
@@ -328,7 +328,16 @@ function Get-VmsCameraReport {
                         $src = [VideoOS.Platform.Data.RawVideoSource]::new($item)
                         $src.Init()
                         $videoFound = $src.GetNext($now.AddDays(-$configuredRetentionDays))
-                        $cache.TrueRetention[$Id] = $videoFound.List[0].DateTime
+                        if ($null -eq $videoFound -or $null -eq $videoFound.List -or $videoFound.List.Count -lt 1) {
+                            return
+                        }
+
+                        $gopStart = $videoFound.List[0]
+                        if ($null -eq $gopStart) {
+                            return
+                        }
+
+                        $cache.TrueRetention[$Id] = $gopStart.DateTime
                     }
 
                     $trueRetentionJobs = @()

--- a/MilestonePSTools/Public/Reports/Get-VmsCameraReport.ps1
+++ b/MilestonePSTools/Public/Reports/Get-VmsCameraReport.ps1
@@ -520,9 +520,12 @@ function Get-VmsCameraReport {
 
                             }
                             if ($IncludeRetentionInfo) {
-                                $obj.MediaDatabaseBegin   = $cache.PlaybackInfo[$id].Begin
-                                $obj.MediaDatabaseEnd     = $cache.PlaybackInfo[$id].End
-                                $obj.HasEvidenceLock      = $evidenceLockedDeviceIds.Contains($id)
+                                $obj.MediaDatabaseBegin           = $cache.PlaybackInfo[$id].Begin
+                                $obj.MediaDatabaseEnd             = $cache.PlaybackInfo[$id].End
+                                $obj.HasEvidenceLock              = $evidenceLockedDeviceIds.Contains($id)
+                                $obj.OldestVideoInRetentionWindow = $null
+                                $obj.ActualRetentionDays          = [double]0
+                                $obj.MeetsRetentionPolicy         = $null
                                 if ($obj.HasEvidenceLock -and $cache.TrueRetention.ContainsKey($id)) {
                                     # True retention walk found non-locked video
                                     $trueBegin = $cache.TrueRetention[$id]

--- a/MilestonePSTools/Public/Reports/Get-VmsCameraReport.ps1
+++ b/MilestonePSTools/Public/Reports/Get-VmsCameraReport.ps1
@@ -310,7 +310,7 @@ function Get-VmsCameraReport {
                     Write-Verbose 'Starting true retention threadjobs for evidence-locked cameras'
                     $trueRetentionScriptBlock = {
                         param(
-                            [guid]$Id,
+                            [VideoOS.Platform.ConfigItem]$CameraItem,
                             [double]$ConfiguredRetentionDays
                         )
 
@@ -318,15 +318,15 @@ function Get-VmsCameraReport {
                         # to find the GOP less than or equal to the configured retention.
                         $now = (Get-Date).ToUniversalTime()
                         try {
-                            $item = Get-VmsVideoOSItem -Kind Camera -Id $Id
-                            $src = [VideoOS.Platform.Data.RawVideoSource]::new($item)
+                            $src = [VideoOS.Platform.Data.RawVideoSource]::new($CameraItem)
                             $src.Init()
                             $videoFound = $src.GetNext($now.AddDays(-$ConfiguredRetentionDays))
                             if ($videoFound.List.Count -lt 1 -or $null -eq $videoFound.List[0]) {
+                                Write-Verbose "No recordings found within the configured retention period for camera with ID '$($CameraItem.FQID.ObjectId)'."
                                 return
                             }
                             [pscustomobject]@{
-                                Id        = $Id
+                                Id        = $CameraItem.FQID.ObjectId
                                 TrueBegin = $videoFound.List[0].DateTime
                             }
                         } finally {
@@ -344,14 +344,21 @@ function Get-VmsCameraReport {
                                     continue
                                 }
                                 if (-not $cache.PlaybackInfo.ContainsKey([guid]$cam.Id)) {
+                                    Write-Warning "Evidence lock found for $($cam.Name) but Get-PlaybackInfo did not return the first and last timestamps from the media database"
                                     continue
                                 }
-                                $storage = $rec.StorageFolder.Storages | Where-Object Path -EQ $cam.RecordingStorage
+                                $storage = $rec | Get-VmsStorage | Where-Object Path -EQ $cam.RecordingStorage
                                 if ($null -eq $storage) {
+                                    Write-Error "Unable to find storage '$($cam.RecordingStorage)' for camera '$($cam.Name)' on recording server '$($rec.Name)'." -TargetObject $cam
+                                    continue
+                                }
+                                $item = Get-VmsVideoOSItem -Kind Camera -Id $cam.Id
+                                if ($null -eq $item) {
+                                    Write-Error ($script:Messages.VideoOSDeviceNotFound -f $cam.Name) -TargetObject $cam
                                     continue
                                 }
                                 $trueRetentionJobs += $jobRunner.AddJob($trueRetentionScriptBlock, @{
-                                    Id                      = $cam.Id
+                                    CameraItem              = $item
                                     ConfiguredRetentionDays = ($storage | Get-VmsStorageRetention).TotalDays
                                 })
                             }

--- a/MilestonePSTools/Public/Reports/Get-VmsCameraReport.ps1
+++ b/MilestonePSTools/Public/Reports/Get-VmsCameraReport.ps1
@@ -533,9 +533,10 @@ function Get-VmsCameraReport {
                                     $obj.OldestVideoInRetentionWindow = $trueBegin
                                     $obj.ActualRetentionDays = [math]::Round(($retentionEnd - $trueBegin).TotalDays, 2)
                                 } elseif ($obj.HasEvidenceLock) {
-                                    # Evidence locks present but no non-locked video found within the retention window
+                                    # Evidence locks are present, but true retention was not populated.
+                                    # Leave values as $null so unknown/unavailable is not reported as zero retention.
                                     $obj.OldestVideoInRetentionWindow = $null
-                                    $obj.ActualRetentionDays = [double]0
+                                    $obj.ActualRetentionDays = $null
                                 } elseif ($null -ne $cache.PlaybackInfo[$id].Begin -and $null -ne $cache.PlaybackInfo[$id].End) {
                                     # No evidence locks - use standard PlaybackInfo
                                     $obj.OldestVideoInRetentionWindow = $cache.PlaybackInfo[$id].Begin

--- a/MilestonePSTools/Public/Reports/Get-VmsCameraReport.ps1
+++ b/MilestonePSTools/Public/Reports/Get-VmsCameraReport.ps1
@@ -102,6 +102,7 @@ function Get-VmsCameraReport {
             $cache = @{
                 DeviceState    = @{}
                 PlaybackInfo   = @{}
+                TrueRetention  = @{}
                 Snapshots      = @{}
                 Passwords      = @{}
                 RecordingStats = @{}
@@ -195,6 +196,20 @@ function Get-VmsCameraReport {
             }
 
             if ($IncludeRetentionInfo) {
+                Write-Verbose 'Fetching evidence locks'
+                $evidenceLockedDeviceIds = [System.Collections.Generic.HashSet[guid]]::new()
+                try {
+                    $evidenceLocks = Get-EvidenceLock -ErrorAction Stop
+                    foreach ($lock in $evidenceLocks) {
+                        foreach ($deviceId in $lock.DeviceIds) {
+                            $null = $evidenceLockedDeviceIds.Add($deviceId)
+                        }
+                    }
+                    Write-Verbose "Found $($evidenceLockedDeviceIds.Count) device(s) with evidence locks"
+                } catch {
+                    Write-Verbose "Unable to retrieve evidence locks: $_"
+                }
+
                 Write-Verbose 'Starting Get-PlaybackInfo threadjob'
                 $playbackInfoScriptblock = {
                     param(
@@ -287,6 +302,70 @@ function Get-VmsCameraReport {
                 $playbackInfoResult = $jobRunner.ReceiveJobs($playbackInfoJobs)
                 foreach ($e in $playbackInfoResult.Errors) {
                     Write-Error $e
+                }
+
+                # For cameras with evidence locks, find the true retention begin by
+                # walking from the configured retention boundary toward the present,
+                # skipping evidence-locked video that would have otherwise been deleted.
+                if ($evidenceLockedDeviceIds.Count -gt 0) {
+                    Write-Verbose 'Starting true retention threadjobs for evidence-locked cameras'
+                    $trueRetentionScriptBlock = {
+                        param(
+                            [guid]$Id,
+                            [double]$ConfiguredRetentionDays,
+                            [hashtable]$cache
+                        )
+                        $playbackInfo = $cache.PlaybackInfo[$Id]
+                        if ($null -eq $playbackInfo) {
+                            return
+                        }
+
+                        # Start from the configured retention boundary and walk forward
+                        # to find the oldest video within the retention window.
+                        # With the formula StartTime=now-($day+1), EndTime=now-$day,
+                        # we want the first window's StartTime to align with the
+                        # retention boundary (now - ConfiguredRetentionDays).
+                        $day = [math]::Ceiling($ConfiguredRetentionDays) - 1
+                        $now = (Get-Date).ToUniversalTime()
+                        $videoFound = $null
+
+                        while (-not $videoFound -and $day -ge 0) {
+                            $videoFound = Get-SequenceData -Path "Camera[$Id]" -StartTime $now.AddDays(-$day - 1) -EndTime $now.AddDays(-$day) | Select-Object -First 1
+                            if ($videoFound) {
+                                $cache.TrueRetention[$Id] = $videoFound.EventSequence.StartDateTime
+                            }
+                            $day--
+                        }
+                    }
+
+                    $trueRetentionJobs = @()
+                    foreach ($rec in $RecordingServer) {
+                        foreach ($hw in $rec.HardwareFolder.Hardwares) {
+                            foreach ($cam in $hw.CameraFolder.Cameras) {
+                                $camId = [guid]$cam.Id
+                                if ($evidenceLockedDeviceIds.Contains($camId) -and $camId -in $ids) {
+                                    $storage = $rec.StorageFolder.Storages | Where-Object Path -EQ $cam.RecordingStorage
+                                    if ($null -ne $storage) {
+                                        $configuredRetentionDays = ($storage | Get-VmsStorageRetention).TotalDays
+                                        $trueRetentionJobs += $jobRunner.AddJob($trueRetentionScriptBlock, @{
+                                            Id                      = $camId
+                                            ConfiguredRetentionDays = $configuredRetentionDays
+                                            cache                   = $cache
+                                        })
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    if ($trueRetentionJobs.Count -gt 0) {
+                        Write-Verbose 'Receiving results of true retention threadjobs'
+                        $jobRunner.Wait($trueRetentionJobs)
+                        $trueRetentionResult = $jobRunner.ReceiveJobs($trueRetentionJobs)
+                        foreach ($e in $trueRetentionResult.Errors) {
+                            Write-Error $e
+                        }
+                    }
                 }
             }
 
@@ -441,10 +520,24 @@ function Get-VmsCameraReport {
 
                             }
                             if ($IncludeRetentionInfo) {
-                                $obj.ActualRetentionDays  = ($cache.PlaybackInfo[$id].End - $cache.PlaybackInfo[$id].Begin).TotalDays
-                                $obj.MeetsRetentionPolicy = $obj.ActualRetentionDays -gt $obj.ExpectedRetentionDays
                                 $obj.MediaDatabaseBegin   = $cache.PlaybackInfo[$id].Begin
                                 $obj.MediaDatabaseEnd     = $cache.PlaybackInfo[$id].End
+                                $obj.HasEvidenceLock      = $evidenceLockedDeviceIds.Contains($id)
+                                if ($obj.HasEvidenceLock -and $cache.TrueRetention.ContainsKey($id)) {
+                                    # True retention walk found non-locked video
+                                    $trueBegin = $cache.TrueRetention[$id]
+                                    $obj.OldestVideoInRetentionWindow = $trueBegin
+                                    $obj.ActualRetentionDays = [math]::Round(((Get-Date).ToUniversalTime() - $trueBegin).TotalDays, 2)
+                                } elseif ($obj.HasEvidenceLock) {
+                                    # Evidence locks present but no non-locked video found within the retention window
+                                    $obj.OldestVideoInRetentionWindow = $null
+                                    $obj.ActualRetentionDays = [double]0
+                                } elseif ($null -ne $cache.PlaybackInfo[$id].Begin -and $null -ne $cache.PlaybackInfo[$id].End) {
+                                    # No evidence locks - use standard PlaybackInfo
+                                    $obj.OldestVideoInRetentionWindow = $cache.PlaybackInfo[$id].Begin
+                                    $obj.ActualRetentionDays = [math]::Round(($cache.PlaybackInfo[$id].End - $cache.PlaybackInfo[$id].Begin).TotalDays, 2)
+                                }
+                                $obj.MeetsRetentionPolicy = if ($null -ne $obj.ActualRetentionDays) { $obj.ActualRetentionDays -ge $obj.ExpectedRetentionDays } else { $null }
                             }
 
                             $obj.MotionEnabled = $motion.Enabled

--- a/MilestonePSTools/Public/Reports/Get-VmsCameraReport.ps1
+++ b/MilestonePSTools/Public/Reports/Get-VmsCameraReport.ps1
@@ -311,51 +311,48 @@ function Get-VmsCameraReport {
                     $trueRetentionScriptBlock = {
                         param(
                             [guid]$Id,
-                            [double]$ConfiguredRetentionDays,
-                            [bool]$HasPlaybackInfo
+                            [double]$ConfiguredRetentionDays
                         )
-
-                        if (-not $HasPlaybackInfo) {
-                            return
-                        }
 
                         # Use the GetNext method on VideoOS.Platform.Data.RawVideoSource
                         # to find the GOP less than or equal to the configured retention.
                         $now = (Get-Date).ToUniversalTime()
-
-                        $item = Get-VmsVideoOSItem -Kind Camera -Id $Id
-                        $src = [VideoOS.Platform.Data.RawVideoSource]::new($item)
-                        $src.Init()
-                        $videoFound = $src.GetNext($now.AddDays(-$ConfiguredRetentionDays))
-                        if ($null -eq $videoFound -or $null -eq $videoFound.List -or $videoFound.List.Count -lt 1) {
-                            return
+                        try {
+                            $item = Get-VmsVideoOSItem -Kind Camera -Id $Id
+                            $src = [VideoOS.Platform.Data.RawVideoSource]::new($item)
+                            $src.Init()
+                            $videoFound = $src.GetNext($now.AddDays(-$ConfiguredRetentionDays))
+                            if ($videoFound.List.Count -lt 1 -or $null -eq $videoFound.List[0]) {
+                                return
+                            }
+                            [pscustomobject]@{
+                                Id        = $Id
+                                TrueBegin = $videoFound.List[0].DateTime
+                            }
+                        } finally {
+                            if ($src) {
+                                $src.Close()
+                            }
                         }
-
-                        $gopStart = $videoFound.List[0]
-                        if ($null -eq $gopStart) {
-                            return
-                        }
-
-                        [pscustomobject]@{ Id = $Id; TrueBegin = $gopStart.DateTime }
                     }
 
                     $trueRetentionJobs = @()
                     foreach ($rec in $RecordingServer) {
                         foreach ($hw in $rec.HardwareFolder.Hardwares) {
                             foreach ($cam in $hw.CameraFolder.Cameras) {
-                                $camId = [guid]$cam.Id
-                                if (-not $evidenceLockedDeviceIds.Contains($camId)) {
+                                if (-not $evidenceLockedDeviceIds.Contains($cam.Id)) {
+                                    continue
+                                }
+                                if (-not $cache.PlaybackInfo.ContainsKey([guid]$cam.Id)) {
                                     continue
                                 }
                                 $storage = $rec.StorageFolder.Storages | Where-Object Path -EQ $cam.RecordingStorage
                                 if ($null -eq $storage) {
                                     continue
                                 }
-                                $configuredRetentionDays = ($storage | Get-VmsStorageRetention).TotalDays
                                 $trueRetentionJobs += $jobRunner.AddJob($trueRetentionScriptBlock, @{
-                                    Id                      = $camId
-                                    ConfiguredRetentionDays = $configuredRetentionDays
-                                    HasPlaybackInfo         = $cache.PlaybackInfo.ContainsKey($camId)
+                                    Id                      = $cam.Id
+                                    ConfiguredRetentionDays = ($storage | Get-VmsStorageRetention).TotalDays
                                 })
                             }
                         }

--- a/MilestonePSTools/Public/Reports/Get-VmsCameraReport.ps1
+++ b/MilestonePSTools/Public/Reports/Get-VmsCameraReport.ps1
@@ -344,17 +344,19 @@ function Get-VmsCameraReport {
                         foreach ($hw in $rec.HardwareFolder.Hardwares) {
                             foreach ($cam in $hw.CameraFolder.Cameras) {
                                 $camId = [guid]$cam.Id
-                                if ($evidenceLockedDeviceIds.Contains($camId) -and $camId -in $ids) {
-                                    $storage = $rec.StorageFolder.Storages | Where-Object Path -EQ $cam.RecordingStorage
-                                    if ($null -ne $storage) {
-                                        $configuredRetentionDays = ($storage | Get-VmsStorageRetention).TotalDays
-                                        $trueRetentionJobs += $jobRunner.AddJob($trueRetentionScriptBlock, @{
-                                            Id                      = $camId
-                                            ConfiguredRetentionDays = $configuredRetentionDays
-                                            HasPlaybackInfo         = $cache.PlaybackInfo.ContainsKey($camId)
-                                        })
-                                    }
+                                if (-not $evidenceLockedDeviceIds.Contains($camId)) {
+                                    continue
                                 }
+                                $storage = $rec.StorageFolder.Storages | Where-Object Path -EQ $cam.RecordingStorage
+                                if ($null -eq $storage) {
+                                    continue
+                                }
+                                $configuredRetentionDays = ($storage | Get-VmsStorageRetention).TotalDays
+                                $trueRetentionJobs += $jobRunner.AddJob($trueRetentionScriptBlock, @{
+                                    Id                      = $camId
+                                    ConfiguredRetentionDays = $configuredRetentionDays
+                                    HasPlaybackInfo         = $cache.PlaybackInfo.ContainsKey($camId)
+                                })
                             }
                         }
                     }

--- a/MilestonePSTools/en-US/messages.psd1
+++ b/MilestonePSTools/en-US/messages.psd1
@@ -18,4 +18,5 @@
     PrebufferSecondsExceedsMaximumValue = 'PrebufferSeconds exceeds the maximum of value for in-memory buffering. The value will be updated to 15 seconds.'
     ClientServiceValidateResult         = 'Validation error: Failed to set {0} to "{1}". Reason: {2}.'
     FalseNotAllowedForRecordedProperty  = 'Value cannot be false for Recorded. To stop recording this stream, assign Primary to another stream using "-RecordingTrack Primary".'
+    VideoOSDeviceNotFound               = 'Device ''{0}'' not found. It may have been added or enabled after the last configuration refresh. Try again after running Clear-VmsCache or Connect-Vms.'
 }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,7 +7,17 @@ hide:
 
 ## [vNext] unreleased
 
-### 🐛 Fixed
+### � Changed
+
+- **`Get-VmsCameraReport`** with `-IncludeRetentionInfo` now accounts for Evidence Locks when calculating
+  `ActualRetentionDays` and `MeetsRetentionPolicy`. Previously, if an Evidence Lock preserved video older than the
+  configured retention, those values would reflect the age of the oldest locked video rather than the oldest
+  non-locked video within the retention window. Two new output columns are also included when using
+  `-IncludeRetentionInfo`: `HasEvidenceLock` indicates whether the camera has any active Evidence Locks, and
+  `OldestVideoInRetentionWindow` is the timestamp of the oldest non-locked video within the configured retention
+  window. Addresses [Issue 160](https://github.com/milestonesys/MilestonePSTools/issues/160).
+
+### �🐛 Fixed
 
 - Fixed [Issue 184](https://github.com/milestonesys/MilestonePSTools/issues/184) where `Get-VmsCameraReport` returned
   empty values for the `ConfiguredRecordedResolution`, `ConfiguredRecordedCodec`, and `ConfiguredRecordedFPS` columns.

--- a/docs/commands/en-US/Get-VmsCameraReport.md
+++ b/docs/commands/en-US/Get-VmsCameraReport.md
@@ -108,7 +108,7 @@ Accept wildcard characters: False
 ```
 
 ### -IncludeRetentionInfo
-Specifies that the report should timestamps for the first and last recorded images, and whether each camera meets the configured retention settings for the storage configuration.
+Specifies that the report should include timestamps for the first and last recorded images, a timestamp for the oldest video within the configured retention (useful if Evidence Locks are in use), the actual number of days of video (excluding Evidence Locks outside the configured retention), and whether each camera meets the configured retention settings for the storage configuration.
 
 ```yaml
 Type: SwitchParameter

--- a/docs/commands/en-US/Get-VmsCameraReport.md
+++ b/docs/commands/en-US/Get-VmsCameraReport.md
@@ -108,7 +108,7 @@ Accept wildcard characters: False
 ```
 
 ### -IncludeRetentionInfo
-Specifies that the report should include timestamps for the first and last recorded images, a timestamp for the oldest video within the configured retention (useful if Evidence Locks are in use), the actual number of days of video (excluding Evidence Locks outside the configured retention), and whether each camera meets the configured retention settings for the storage configuration.
+Specifies that the report should include additional retention-related output columns for each camera, including the timestamps of the first and last recorded images, the timestamp of the oldest video that still falls within the configured retention window (useful when Evidence Locks preserve older video), the actual number of retained video days excluding Evidence Locks outside the configured retention window, and whether the camera currently meets the configured retention setting for its storage configuration.
 
 ```yaml
 Type: SwitchParameter

--- a/psakefile.ps1
+++ b/psakefile.ps1
@@ -94,6 +94,7 @@ using namespace VideoOS.Platform.ConfigurationItems
             RequiredVersion = '7.8.9'
         }
     )
+    $PesterTags = $Tags
 }
 
 Task Default -depends StageCmdletLib, Build, UpdateModuleExports, ExportCommandHistory, UpdateCommandIndexTable, generate-compatibility-table
@@ -530,7 +531,6 @@ Task -name mkdocs-serve -depends PullMkdocsMaterialImage, generate-compatibility
 
 Task -name integration-tests -description 'Run integration tests from the tests/MilestonePSTools folder' {
     $outputModVerManifest = Join-Path -Path $env:BHBuildOutput -ChildPath "$($env:BHProjectName).psd1"
-    
     $integrationTestEntrypoint = Join-Path $psake.build_script_dir 'tests/MilestonePSTools/MilestonePSTools.integration.tests.ps1'
     $testConfig = New-PesterConfiguration -Hashtable @{
         Run = @{
@@ -539,6 +539,9 @@ Task -name integration-tests -description 'Run integration tests from the tests/
             }
             SkipRemainingOnFailure = 'Container'
             Throw = $true
+        }
+        Filter = @{
+            Tag = $PesterTags
         }
         Output = @{
             Verbosity = 'Detailed'

--- a/tests/MilestonePSTools/read-write/Get-VmsCameraReport.integration.ps1
+++ b/tests/MilestonePSTools/read-write/Get-VmsCameraReport.integration.ps1
@@ -154,7 +154,11 @@ Context 'Get-VmsCameraReport' -Skip:($script:SkipReadWriteTests) {
         }
         $hasEvidenceLock.HasEvidenceLock | Should -Be $true -Because 'HasEvidenceLock should be true when evidence lock is present.'
         $hasEvidenceLock | Should -HaveProperty 'OldestVideoInRetentionWindow' -Because 'OldestVideoInRetentionWindow should be present.'
-        $hasEvidenceLock.OldestVideoInRetentionWindow | Should -Not -BeNullOrEmpty -Because 'OldestVideoInRetentionWindow should not be null when evidence lock is present.'
-        $hasEvidenceLock.OldestVideoInRetentionWindow | Should -BeOfType -ExpectedType [datetime] -Because 'OldestVideoInRetentionWindow should be a datetime.'
+        if ($null -ne $hasEvidenceLock.OldestVideoInRetentionWindow) {
+            $hasEvidenceLock.OldestVideoInRetentionWindow | Should -BeOfType -ExpectedType [datetime] -Because 'OldestVideoInRetentionWindow should be a datetime when non-null.'
+        }
+        else {
+            $hasEvidenceLock.ActualRetentionDays | Should -Be 0 -Because 'OldestVideoInRetentionWindow may be null when all video in the retention window is evidence-locked.'
+        }
     }
 }

--- a/tests/MilestonePSTools/read-write/Get-VmsCameraReport.integration.ps1
+++ b/tests/MilestonePSTools/read-write/Get-VmsCameraReport.integration.ps1
@@ -72,6 +72,8 @@ Context 'Get-VmsCameraReport' -Skip:($script:SkipReadWriteTests) {
             'UsedSpaceInGB',
             'ActualRetentionDays',
             'MeetsRetentionPolicy',
+            'HasEvidenceLock',
+            'OldestVideoInRetentionWindow',
             'MotionEnabled',
             'MotionKeyframesOnly',
             'MotionProcessTime',
@@ -142,5 +144,17 @@ Context 'Get-VmsCameraReport' -Skip:($script:SkipReadWriteTests) {
         $cameraWithStreams | Should -Not -BeNullOrEmpty -Because 'At least one camera should have a populated LiveStream name, indicating StreamFolder.Streams was populated correctly after FillChildren'
         $cameraWithStreams.LiveStreamDescription | Should -Not -BeNullOrEmpty -Because 'LiveStreamDescription should be populated when LiveStream is populated'
         $cameraWithStreams.RecordedStream | Should -Not -BeNullOrEmpty -Because 'RecordedStream should be populated when LiveStream is populated'
+    }
+
+    It 'Has correct HasEvidenceLock and OldestVideoInRetentionWindow behavior' {
+        $hasEvidenceLock = $script:camerareport | Where-Object { $_.HasEvidenceLock -eq $true } | Select-Object -First 1
+        if ($null -eq $hasEvidenceLock) {
+            Set-ItResult -Skipped -Because 'No cameras with evidence locks present in this environment.'
+            return
+        }
+        $hasEvidenceLock.HasEvidenceLock | Should -Be $true -Because 'HasEvidenceLock should be true when evidence lock is present.'
+        $hasEvidenceLock | Should -HaveProperty 'OldestVideoInRetentionWindow' -Because 'OldestVideoInRetentionWindow should be present.'
+        $hasEvidenceLock.OldestVideoInRetentionWindow | Should -Not -BeNullOrEmpty -Because 'OldestVideoInRetentionWindow should not be null when evidence lock is present.'
+        $hasEvidenceLock.OldestVideoInRetentionWindow | Should -BeOfType -ExpectedType [datetime] -Because 'OldestVideoInRetentionWindow should be a datetime.'
     }
 }

--- a/tests/MilestonePSTools/read-write/Get-VmsCameraReport.integration.ps1
+++ b/tests/MilestonePSTools/read-write/Get-VmsCameraReport.integration.ps1
@@ -158,7 +158,7 @@ Context 'Get-VmsCameraReport' -Skip:($script:SkipReadWriteTests) {
             $hasEvidenceLock.OldestVideoInRetentionWindow | Should -BeOfType -ExpectedType [datetime] -Because 'OldestVideoInRetentionWindow should be a datetime when non-null.'
         }
         else {
-            $hasEvidenceLock.ActualRetentionDays | Should -Be 0 -Because 'OldestVideoInRetentionWindow may be null when all video in the retention window is evidence-locked.'
+            $hasEvidenceLock.ActualRetentionDays | Should -BeIn @($null, 0) -Because 'When OldestVideoInRetentionWindow is null, true retention may be unknown/unavailable or explicitly 0 when all video in the retention window is evidence-locked.'
         }
     }
 }

--- a/tests/MilestonePSTools/read-write/Get-VmsCameraReport.integration.ps1
+++ b/tests/MilestonePSTools/read-write/Get-VmsCameraReport.integration.ps1
@@ -1,4 +1,4 @@
-Context 'Get-VmsCameraReport' -Skip:($script:SkipReadWriteTests) {
+Context 'Get-VmsCameraReport' -Skip:($script:SkipReadWriteTests) -Tag 'Get-VmsCameraReport' {
     BeforeAll {
         $script:camerareport = @()
         $script:expectedColumns = @(
@@ -86,8 +86,39 @@ Context 'Get-VmsCameraReport' -Skip:($script:SkipReadWriteTests) {
             'PrivacyMaskEnabled',
             'Snapshot'
         )
-        Get-VmsCamera -EnableFilter All | Set-VmsCamera -Enabled $true -ErrorAction Stop
+        Get-VmsCamera -EnableFilter All | Set-VmsCamera -Enabled $true -ErrorAction Stop -PassThru
+        if (Test-VmsLicensedFeature -Name EvidenceLock) {
+            $lockNumber = 1
+            $script:evidenceLocks = Get-VmsCamera | ForEach-Object {
+                try {
+                    $splat = @{
+                        CameraIds     = $_.Id
+                        Header        = "Test Evidence Lock $lockNumber"
+                        FootageFrom   = (Get-Date).AddDays(-1)
+                        FootageTo     = (Get-Date).AddSeconds(-10)
+                        RetentionType = 'Indefinite'
+                        ErrorAction   = 'Stop'
+                    }
+                    Add-EvidenceLock @splat
+                    $lockNumber++
+                } catch {
+                    Write-Warning "Failed to create evidence lock. $($_.Exception.Message)"
+                }
+            }
+        }
         Clear-VmsCache
+    }
+
+    AfterAll {
+        if (Test-VmsLicensedFeature -Name EvidenceLock) {
+            foreach ($lock in $script:evidenceLocks) {
+                try {
+                    $lock.MarkedData | Remove-EvidenceLock -Force -Confirm:$false -ErrorAction Stop
+                } catch {
+                    Write-Warning "Failed to remove evidence lock. $($_.Exception.Message)"
+                }
+            }
+        }
     }
 
     It 'Completes without error' {
@@ -98,6 +129,7 @@ Context 'Get-VmsCameraReport' -Skip:($script:SkipReadWriteTests) {
                     Send-MipMessage -MessageId Control.StartRecordingCommand -DestinationEndpoint $fqid -UseEnvironmentManager
                 }
             }
+
             Start-Sleep -Seconds 10
             $script:camerareport += Get-VmsCameraReport -IncludePlainTextPasswords -IncludeRetentionInfo -IncludeRecordingStats -IncludeSnapshots -SnapshotTimeoutMS 20000 -ErrorAction Stop
         } | Should -Not -Throw
@@ -146,18 +178,18 @@ Context 'Get-VmsCameraReport' -Skip:($script:SkipReadWriteTests) {
         $cameraWithStreams.RecordedStream | Should -Not -BeNullOrEmpty -Because 'RecordedStream should be populated when LiveStream is populated'
     }
 
-    It 'Has correct HasEvidenceLock and OldestVideoInRetentionWindow behavior' {
+    It 'Has correct HasEvidenceLock and OldestVideoInRetentionWindow behavior' -Skip:(-not (Test-VmsLicensedFeature -Name EvidenceLock)) {
         $hasEvidenceLock = $script:camerareport | Where-Object { $_.HasEvidenceLock -eq $true } | Select-Object -First 1
         if ($null -eq $hasEvidenceLock) {
             Set-ItResult -Skipped -Because 'No cameras with evidence locks present in this environment.'
             return
         }
         $hasEvidenceLock.HasEvidenceLock | Should -Be $true -Because 'HasEvidenceLock should be true when evidence lock is present.'
-        $hasEvidenceLock | Should -HaveProperty 'OldestVideoInRetentionWindow' -Because 'OldestVideoInRetentionWindow should be present.'
+        $oldestVideoProp = $hasEvidenceLock.psobject.Properties | Where-Object Name -eq 'OldestVideoInRetentionWindow'
+        $oldestVideoProp | Should -Not -BeNullOrEmpty -Because 'OldestVideoInRetentionWindow property should be present.'
         if ($null -ne $hasEvidenceLock.OldestVideoInRetentionWindow) {
             $hasEvidenceLock.OldestVideoInRetentionWindow | Should -BeOfType -ExpectedType [datetime] -Because 'OldestVideoInRetentionWindow should be a datetime when non-null.'
-        }
-        else {
+        } else {
             $hasEvidenceLock.ActualRetentionDays | Should -BeIn @($null, 0) -Because 'When OldestVideoInRetentionWindow is null, true retention may be unknown/unavailable or explicitly 0 when all video in the retention window is evidence-locked.'
         }
     }


### PR DESCRIPTION
## Description
The current way `-IncludeRetentionInfo` performs is that it just finds the oldest video and checks if it is older than or equal to the configured retention. That works fine, except when evidence locks are in use. If there is an evidence lock on video that is older than the configured retention, then the retention that is returned doesn't tell you if  there is even any non-evidenced locked video in the retention window.

This change checks to see if the camera has evidence locks. If it does, it uses a method to find the closest GOP to the configured retention time and uses that start time to check if

## Related Issue
https://github.com/milestonesys/MilestonePSTools/issues/160

## Motivation and Context
This makes it so the actual retention mentioned in the output excludes evidence locked video that might exist after the configured retention. That way the user gets a more accurate value.

## How Has This Been Tested?
Tested it against the current function to make sure nothing else was affected and to make sure the values were accurate.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

