### PR TITLE
Fix & Refactor Import-VmsHardware

### DIFF
--- a/MilestonePSTools/Private/ImportHardwareCommon.ps1
+++ b/MilestonePSTools/Private/ImportHardwareCommon.ps1
@@ -1,0 +1,170 @@
+# Copyright 2025 Milestone Systems A/S
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+function New-ImportHardwareCredentialList {
+    [CmdletBinding()]
+    param(
+        [Parameter()]
+        [AllowNull()]
+        [object]
+        $Credential,
+
+        [Parameter()]
+        [string]
+        $UserName,
+
+        [Parameter()]
+        [string]
+        $Password
+    )
+
+    process {
+        $credentialList = [collections.generic.list[pscredential]]::new()
+        if (-not [string]::IsNullOrWhiteSpace($UserName) -and -not [string]::IsNullOrWhiteSpace($Password)) {
+            $credentialList.Add([pscredential]::new($UserName, ($Password | ConvertTo-SecureString -AsPlainText -Force)))
+        }
+
+        if ($null -eq $Credential) {
+            return $credentialList
+        }
+
+        if ($Credential -is [pscredential]) {
+            $credentialList.Add($Credential)
+            return $credentialList
+        }
+
+        foreach ($item in $Credential) {
+            if ($item -is [pscredential] -and $null -ne $item) {
+                $credentialList.Add($item)
+            }
+        }
+
+        return $credentialList
+    }
+}
+
+function Set-ImportHardwareScanCredentialParameters {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [hashtable]
+        $ScanParameters,
+
+        [Parameter()]
+        [AllowNull()]
+        [object]
+        $Credential
+    )
+
+    process {
+        $scanCredentials = New-ImportHardwareCredentialList -Credential $Credential
+        if ($scanCredentials.Count -gt 0) {
+            $ScanParameters.Credential = $scanCredentials
+            if ($ScanParameters.ContainsKey('UseDefaultCredentials')) {
+                $ScanParameters.Remove('UseDefaultCredentials')
+            }
+        } else {
+            $ScanParameters.UseDefaultCredentials = $true
+            if ($ScanParameters.ContainsKey('Credential')) {
+                $ScanParameters.Remove('Credential')
+            }
+        }
+
+        return $ScanParameters
+    }
+}
+
+function Invoke-ImportHardwareCredentialAttempts {
+    [CmdletBinding()]
+    [OutputType([object])]
+    param(
+        [Parameter()]
+        [AllowNull()]
+        [object]
+        $Credential,
+
+        [Parameter(Mandatory)]
+        [scriptblock]
+        $AttemptScript,
+
+        [Parameter()]
+        [scriptblock]
+        $OnAttemptFailure,
+
+        [Parameter()]
+        [switch]
+        $RethrowOnException
+    )
+
+    process {
+        $credentials = New-ImportHardwareCredentialList -Credential $Credential
+        for ($credIndex = 0; $credIndex -lt $credentials.Count; $credIndex++) {
+            $cred = $credentials[$credIndex]
+            $isLastAttempt = $credIndex -ge $credentials.Count - 1
+            $attemptResult = $null
+            $errorRecord = $null
+
+            try {
+                $attemptResult = & $AttemptScript $cred $credIndex $isLastAttempt
+            } catch {
+                if ($RethrowOnException) {
+                    throw
+                }
+                $errorRecord = $_
+            }
+
+            $success = $null -ne $attemptResult
+            $value = $attemptResult
+            if ($attemptResult -is [hashtable]) {
+                if ($attemptResult.ContainsKey('Success')) {
+                    $success = [bool]$attemptResult.Success
+                }
+                if ($attemptResult.ContainsKey('Value')) {
+                    $value = $attemptResult.Value
+                }
+                if ($null -eq $errorRecord -and $attemptResult.ContainsKey('ErrorRecord')) {
+                    $errorRecord = $attemptResult.ErrorRecord
+                }
+            } elseif ($attemptResult -is [pscustomobject]) {
+                if ($attemptResult.PSObject.Properties.Name -contains 'Success') {
+                    $success = [bool]$attemptResult.Success
+                }
+                if ($attemptResult.PSObject.Properties.Name -contains 'Value') {
+                    $value = $attemptResult.Value
+                }
+                if ($null -eq $errorRecord -and $attemptResult.PSObject.Properties.Name -contains 'ErrorRecord') {
+                    $errorRecord = $attemptResult.ErrorRecord
+                }
+            }
+
+            if ($success) {
+                return $value
+            }
+
+            if ($OnAttemptFailure) {
+                & $OnAttemptFailure ([pscustomobject]@{
+                        Credential   = $cred
+                        AttemptIndex = $credIndex
+                        IsLastAttempt = $isLastAttempt
+                        AttemptResult = $attemptResult
+                        ErrorRecord  = $errorRecord
+                    })
+            } elseif ($null -ne $errorRecord) {
+                Write-Error -ErrorRecord $errorRecord
+            }
+        }
+
+        return $null
+    }
+}

--- a/MilestonePSTools/Private/ImportHardwareCsv.ps1
+++ b/MilestonePSTools/Private/ImportHardwareCsv.ps1
@@ -296,7 +296,7 @@ function ImportHardwareCsv {
                                 $hardwareGroup.Group | ForEach-Object {
                                     $_.Result += "Hardware not added - no credentials provided."
                                 }
-                                Write-Warning "Skipping $($hardware.Name) as no credentials have been provided."
+                                Write-Warning "Skipping $($hardwareGroup.Name) as no credentials have been provided."
                             }
                             for ($credIndex = 0; $credIndex -lt $credentials.Count; $credIndex++) {
                                 $cred = $credentials[$credIndex]
@@ -323,14 +323,10 @@ function ImportHardwareCsv {
                                 }
                             }
                             if ($skipHardware) {
-                                $hardwareGroup.Group | ForEach-Object {
-                                    $_.Result += 'Hardware successfully added.'
-                                }
                                 continue
-                            } else {
-                                $hardwareGroup.Group | ForEach-Object {
-                                    $_.Result += 'Hardware successfully added.'
-                                }
+                            }
+                            $hardwareGroup.Group | ForEach-Object {
+                                $_.Result += 'Hardware successfully added.'
                             }
     
                             $hardware = [VideoOS.Platform.ConfigurationItems.Hardware]::new($recorder.ServerId, ($task.Properties | Where-Object Key -EQ 'Path').Value)


### PR DESCRIPTION
## Description
  This PR fixes hardware import correctness issues and refactors shared import logic used by both CSV and XLSX paths.

  Changes included:
  - Fix XLSX new-hardware import flow to avoid silent skip when no usable credentials are available.
  - Fix CSV result reporting so failed add paths are not marked as success.
  - Fix CSV warning text to reference the correct hardware group/address.
  - Add shared private helpers to reduce CSV/XLSX drift in credential normalization, scan credential/default handling, and credential retry flow.

  Main files:
  - `MilestonePSTools/Private/ImportHardwareCommon.ps1` (new)
  - `MilestonePSTools/Private/ImportHardwareCsv.ps1`
  - `MilestonePSTools/Private/ImportVmsHardwareExcelFunctions.ps1`

  Commit stack:
  1. `28379bd` Fix XLSX hardware import credential handling
  2. `92ef83e` Fix CSV import status and warning reporting
  3. `b73c62f` Share CSV/XLSX hardware import helpers

  Low-impact option:
  - If you prefer minimal-risk bug fixes only, cherry-pick:
    - `28379bd`
    - `92ef83e`

  ## Related Issue
  None

  ## Motivation and Context
  CSV and XLSX import implementations had diverged and produced inconsistent outcomes in credential and status-handling paths.
  This PR fixes known bugs and consolidates shared internals to keep behavior aligned moving forward.

  ## How Has This Been Tested?
  - Static code-path review of the updated CSV and XLSX import flows.
  - Validation of staged diffs and commit-level changes.

  Notes:
  - Runtime/integration tests were **not** executed in this environment.
  - PowerShell runtime was unavailable here for executing full test suites.

  ## Screenshots (if appropriate):
  N/A

  ## Types of changes
  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)

  ## Checklist:
  - [x] My code follows the code style of this project.
  - [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
  - [x] I have read the **CONTRIBUTING** document.
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
