### PR TITLE
Improve stream handling for systems without MultistreamRecording

### DIFF
--- a/MilestonePSTools/Public/Set-VmsCameraStream.ps1
+++ b/MilestonePSTools/Public/Set-VmsCameraStream.ps1
@@ -40,6 +40,12 @@ function Set-VmsCameraStream {
         $LiveDefault,
 
         [Parameter(ParameterSetName = 'AddOrUpdateStream')]
+        [ValidateScript({
+            if (!$_) {
+                throw $script:Messages.FalseNotAllowedForRecordedProperty
+            }
+            $true
+        })]
         [switch]
         $Recorded,
 

--- a/MilestonePSTools/en-US/messages.psd1
+++ b/MilestonePSTools/en-US/messages.psd1
@@ -9,12 +9,13 @@
     # into a script-scope variable. Functions can then use these messages by referencing
     # $script:Messages.ListingAllRecorders for example.
 
-    MustBeAdminToReadPasswords = 'You must be in the Administrators role to read hardware passwords.'
-    ListingAllRecorders = 'Listing all recording servers'
-    CallingGetItemState = 'Calling Get-ItemState'
-    StartingFillChildrenThreadJob = 'Starting FillChildren threadjob'
-    CameraOnSiteWithIdNotFound = 'Camera not found on site {0} with ID {1}.'
-    NotConnectedToAManagementServer = 'Not connected to a Milestone XProtect Management Server.'
+    MustBeAdminToReadPasswords          = 'You must be in the Administrators role to read hardware passwords.'
+    ListingAllRecorders                 = 'Listing all recording servers'
+    CallingGetItemState                 = 'Calling Get-ItemState'
+    StartingFillChildrenThreadJob       = 'Starting FillChildren threadjob'
+    CameraOnSiteWithIdNotFound          = 'Camera not found on site {0} with ID {1}.'
+    NotConnectedToAManagementServer     = 'Not connected to a Milestone XProtect Management Server.'
     PrebufferSecondsExceedsMaximumValue = 'PrebufferSeconds exceeds the maximum of value for in-memory buffering. The value will be updated to 15 seconds.'
-    ClientServiceValidateResult = 'Validation error: Failed to set {0} to "{1}". Reason: {2}.'
+    ClientServiceValidateResult         = 'Validation error: Failed to set {0} to "{1}". Reason: {2}.'
+    FalseNotAllowedForRecordedProperty  = 'Value cannot be false for Recorded. To stop recording this stream, assign Primary to another stream using "-RecordingTrack Primary".'
 }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,13 @@ hide:
 
 ## [vNext] unreleased
 
+### 🐛 Fixed
+
+- Fixed [Issue 184](https://github.com/milestonesys/MilestonePSTools/issues/184) where `Get-VmsCameraReport` returned
+  empty values for the `ConfiguredRecordedResolution`, `ConfiguredRecordedCodec`, and `ConfiguredRecordedFPS` columns.
+  This bug also affected `Get-VmsCameraStream` where empty values were returned for the `RecordingTrack` and `Recorded`
+  properties, and `PlaybackDefault` was always `$false`.
+
 ## [25.2.38] 2026-02-02
 
 ### 🔄 Changed

--- a/src/MilestonePSTools/Utility/VmsCameraStreamConfig.cs
+++ b/src/MilestonePSTools/Utility/VmsCameraStreamConfig.cs
@@ -12,14 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using MilestonePSTools.Connection;
 using MilestonePSTools.Extensions;
 using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Management.Automation;
+using System.Windows.Forms;
 using VideoOS.Platform.ConfigurationItems;
 
+#pragma warning disable CS0618 // Type or member is obsolete
+// Record property is only obsolete on 2023 R2 and newer. Still used on older versions.
 namespace MilestonePSTools
 {
     public class VmsCameraStreamConfig
@@ -122,16 +126,49 @@ namespace MilestonePSTools
             }
         }
 
-        public string RecordingTrackName => RecordingTrackFromId[GetStreamUsage()?.RecordTo ?? string.Empty].ToString();
+        public string RecordingTrackName
+        {
+            get
+            {
+                if (SupportsSecondaryRecording())
+                {
+                    return RecordingTrackFromId[GetStreamUsage()?.RecordTo ?? string.Empty].ToString();
+                }
+                else
+                {
+                    return RecordingTrackFromId[
+                        GetStreamUsage()?.Record ?? false
+                        ? RecordingTrackToId[RecordingTracks.Primary]
+                        : RecordingTrackToId[RecordingTracks.None
+                        ]].ToString();
+                }
+            }
+        }
 
         public bool PlaybackDefault
         {
-            get => GetStreamUsage()?.DefaultPlayback ?? false;
+            get
+            {
+                var usage = GetStreamUsage();
+                if (usage == null) return true; // If there is no stream usage, default to true because super old drivers might not have stream usages but still record.
+                if (SupportsSecondaryRecording())
+                {
+                    return usage.DefaultPlayback;
+                }
+                else
+                {
+                    return usage.Record;
+                }
+            }
             set
             {
                 var streamUsage = GetStreamUsage();
-                if (streamUsage == null) return;
-                if (streamUsage?.DefaultPlayback == value) return;
+                // There are no stream usages to configure
+                if (streamUsage == null) return; 
+                // The value is already set to the provided value
+                if (streamUsage.DefaultPlayback == value) return;
+                // The RecordTo property is not set, so this is probably a version without Primary/Secondary tracks
+                if (string.IsNullOrEmpty(streamUsage.RecordTo)) return;
                 streamUsage.DefaultPlayback = value;
                 if (value)
                 {
@@ -162,20 +199,55 @@ namespace MilestonePSTools
         [Hidden()]
         public bool Recorded
         {
-            get => GetStreamUsage()?.RecordTo.Equals(GetStreamUsage().RecordToValues["Primary recording"]) ?? false;
+            get
+            {
+                return SupportsSecondaryRecording()
+                    ? GetStreamUsage()?.RecordTo.Equals(GetStreamUsage().RecordToValues["Primary recording"]) ?? false
+                    : GetStreamUsage()?.Record ?? false;
+            }
             set
             {
                 var streamUsage = GetStreamUsage();
                 if (streamUsage == null) return;
-                RecordingTrack = RecordingTrackToId[RecordingTracks.Primary];
-                PlaybackDefault = true;
+                if (SupportsSecondaryRecording())
+                {
+                    if (value == streamUsage.RecordTo.Equals(RecordingTrackToId[RecordingTracks.Primary]))
+                    {
+                        return;
+                    }
+                    RecordingTrack = RecordingTrackToId[RecordingTracks.Primary];
+                }
+                else
+                {
+                    if (value == streamUsage.Record) return;
+                    var otherUsage = FindStreamUsage(u => u.Record);
+                    if (value && otherUsage != null)
+                    {
+                        otherUsage.Record = false;
+                    }
+                    streamUsage.Record = value;
+                }
+                PlaybackDefault = value;
+                _dirtyStreamDefinition[Camera.Id] = true;
             }
         }
 
         [Hidden()]
         public string RecordingTrack
         {
-            get => GetStreamUsage()?.RecordTo ?? string.Empty;
+            get
+            {
+                if (SupportsSecondaryRecording())
+                {
+                    return GetStreamUsage()?.RecordTo ?? string.Empty;
+                }
+                else
+                {
+                    return GetStreamUsage()?.Record == true
+                        ? RecordingTrackToId[RecordingTracks.Primary]
+                        : string.Empty;
+                }
+            }
             set
             {
                 // Accepts None, Primary, Secondary as well as the actual IDs
@@ -183,23 +255,34 @@ namespace MilestonePSTools
                 {
                     value = RecordingTrackToId[(RecordingTracks)Enum.Parse(typeof(RecordingTracks), value, true)];
                 }
-                var streamUsage = GetStreamUsage();
-                if (streamUsage?.RecordTo.Equals(value, StringComparison.OrdinalIgnoreCase) ?? true) return;
+                if (SupportsSecondaryRecording())
+                {
+                    var streamUsage = GetStreamUsage();
+                    if (streamUsage?.RecordTo.Equals(value, StringComparison.OrdinalIgnoreCase) ?? true) return;
 
-                // If another stream usage is designated the same recording track, set it to None
-                var otherUsage = FindStreamUsage(u => u.RecordTo == value);
-                if (otherUsage != null)
-                {
-                    otherUsage.RecordTo = RecordingTrackToId[RecordingTracks.None];
-                    // The other stream usage can't be the playback default if recording track is set to None
-                    otherUsage.DefaultPlayback = false;
+                    // If another stream usage is designated the same recording track, set it to None
+                    var otherUsage = FindStreamUsage(u => u.RecordTo == value);
+                    if (otherUsage != null)
+                    {
+                        otherUsage.RecordTo = RecordingTrackToId[RecordingTracks.None];
+                        // The other stream usage can't be the playback default if recording track is set to None
+                        otherUsage.DefaultPlayback = false;
+                    }
+                    if (FindStreamUsage(u => u.DefaultPlayback) == null)
+                    {
+                        streamUsage.DefaultPlayback = true;
+                    }
+                    streamUsage.RecordTo = value;
+                    _dirtyStreamDefinition[Camera.Id] = true;
                 }
-                if (FindStreamUsage(u => u.DefaultPlayback) == null)
+                else if (value.Equals(RecordingTrackToId[RecordingTracks.Secondary], StringComparison.OrdinalIgnoreCase))
                 {
-                    streamUsage.DefaultPlayback = true;
+                    throw new NotSupportedException("Secondary recording is not supported. This may be because the XProtect VMS version is older than 2023 R2.");
                 }
-                streamUsage.RecordTo = value;
-                _dirtyStreamDefinition[Camera.Id] = true;
+                else
+                {
+                    Recorded = value.Equals(RecordingTrackToId[RecordingTracks.Primary], StringComparison.OrdinalIgnoreCase);
+                }
             }
         }
 
@@ -251,7 +334,7 @@ namespace MilestonePSTools
 
         public string GetRecordingTrackName()
         {
-            if (RecordToValues.Count > 0)
+            if (SupportsSecondaryRecording())
             {
                 return RecordToValues.Where(r => r.Value == RecordingTrack)
                     .Select(r => r.Key).FirstOrDefault();
@@ -290,6 +373,11 @@ namespace MilestonePSTools
         #endregion
 
         #region Private Methods
+        private bool SupportsSecondaryRecording()
+        {
+            return MilestoneConnection.Instance.SystemLicense.IsFeatureEnabled("MultistreamRecording");
+        }
+
         private StreamUsageChildItem FindStreamUsage(Func<StreamUsageChildItem, bool> predicate)
         {
             return GetStreamDefinition().StreamUsageChildItems
@@ -345,3 +433,4 @@ namespace MilestonePSTools
         }
     }
 }
+#pragma warning restore CS0618 // Type or member is obsolete

--- a/src/MilestonePSTools/Utility/VmsCameraStreamConfig.cs
+++ b/src/MilestonePSTools/Utility/VmsCameraStreamConfig.cs
@@ -19,15 +19,13 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Management.Automation;
-using System.Windows.Forms;
 using VideoOS.Platform.ConfigurationItems;
 
-#pragma warning disable CS0618 // Type or member is obsolete
-// Record property is only obsolete on 2023 R2 and newer. Still used on older versions.
 namespace MilestonePSTools
 {
     public class VmsCameraStreamConfig
     {
+        // Use of the obsolete .Record property is necessary for compatibility with pre-2023 R2 versions without the MultistreamRecording feature.
         #region Static Members
         private static readonly Dictionary<string, bool> _dirtyStreamDefinition = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
         private static readonly Dictionary<string, bool> _dirtyDriverSettings = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
@@ -136,11 +134,13 @@ namespace MilestonePSTools
                 }
                 else
                 {
+#pragma warning disable CS0618 // Type or member is obsolete
                     return RecordingTrackFromId[
                         GetStreamUsage()?.Record ?? false
                         ? RecordingTrackToId[RecordingTracks.Primary]
                         : RecordingTrackToId[RecordingTracks.None
                         ]].ToString();
+#pragma warning restore CS0618 // Type or member is obsolete
                 }
             }
         }
@@ -150,15 +150,12 @@ namespace MilestonePSTools
             get
             {
                 var usage = GetStreamUsage();
-                if (usage == null) return true; // If there is no stream usage, default to true because super old drivers might not have stream usages but still record.
-                if (SupportsSecondaryRecording())
-                {
-                    return usage.DefaultPlayback;
-                }
-                else
-                {
-                    return usage.Record;
-                }
+                if (usage == null) return false;
+#pragma warning disable CS0618 // Type or member is obsolete
+                return SupportsSecondaryRecording()
+                    ? usage.DefaultPlayback
+                    : usage.Record;
+#pragma warning restore CS0618 // Type or member is obsolete
             }
             set
             {
@@ -201,9 +198,13 @@ namespace MilestonePSTools
         {
             get
             {
+                var usage = GetStreamUsage();
+                if (usage == null) return false;
+#pragma warning disable CS0618 // Type or member is obsolete
                 return SupportsSecondaryRecording()
-                    ? GetStreamUsage()?.RecordTo.Equals(GetStreamUsage().RecordToValues["Primary recording"]) ?? false
-                    : GetStreamUsage()?.Record ?? false;
+                    ? usage.RecordTo.Equals(RecordingTrackToId[RecordingTracks.Primary], StringComparison.InvariantCultureIgnoreCase)
+                    : usage.Record;
+#pragma warning restore CS0618 // Type or member is obsolete
             }
             set
             {
@@ -219,6 +220,7 @@ namespace MilestonePSTools
                 }
                 else
                 {
+#pragma warning disable CS0618 // Type or member is obsolete
                     if (value == streamUsage.Record) return;
                     var otherUsage = FindStreamUsage(u => u.Record);
                     if (value && otherUsage != null)
@@ -226,6 +228,7 @@ namespace MilestonePSTools
                         otherUsage.Record = false;
                     }
                     streamUsage.Record = value;
+#pragma warning restore CS0618 // Type or member is obsolete
                 }
                 PlaybackDefault = value;
                 _dirtyStreamDefinition[Camera.Id] = true;
@@ -243,9 +246,11 @@ namespace MilestonePSTools
                 }
                 else
                 {
+#pragma warning disable CS0618 // Type or member is obsolete
                     return GetStreamUsage()?.Record == true
                         ? RecordingTrackToId[RecordingTracks.Primary]
                         : string.Empty;
+#pragma warning restore CS0618 // Type or member is obsolete
                 }
             }
             set
@@ -433,4 +438,3 @@ namespace MilestonePSTools
         }
     }
 }
-#pragma warning restore CS0618 // Type or member is obsolete

--- a/src/MilestonePSTools/Utility/VmsCameraStreamConfig.cs
+++ b/src/MilestonePSTools/Utility/VmsCameraStreamConfig.cs
@@ -216,7 +216,10 @@ namespace MilestonePSTools
                     {
                         return;
                     }
-                    RecordingTrack = RecordingTrackToId[RecordingTracks.Primary];
+                    PlaybackDefault = value ? true : PlaybackDefault;
+                    RecordingTrack = value
+                        ? RecordingTrackToId[RecordingTracks.Primary]
+                        : RecordingTrackToId[RecordingTracks.None];
                 }
                 else
                 {
@@ -230,7 +233,6 @@ namespace MilestonePSTools
                     streamUsage.Record = value;
 #pragma warning restore CS0618 // Type or member is obsolete
                 }
-                PlaybackDefault = value;
                 _dirtyStreamDefinition[Camera.Id] = true;
             }
         }

--- a/src/MilestonePSTools/Utility/VmsCameraStreamConfig.cs
+++ b/src/MilestonePSTools/Utility/VmsCameraStreamConfig.cs
@@ -202,7 +202,7 @@ namespace MilestonePSTools
                 if (usage == null) return false;
 #pragma warning disable CS0618 // Type or member is obsolete
                 return SupportsSecondaryRecording()
-                    ? usage.RecordTo.Equals(RecordingTrackToId[RecordingTracks.Primary], StringComparison.InvariantCultureIgnoreCase)
+                    ? usage.RecordTo.Equals(RecordingTrackToId[RecordingTracks.Primary], StringComparison.OrdinalIgnoreCase)
                     : usage.Record;
 #pragma warning restore CS0618 // Type or member is obsolete
             }
@@ -212,7 +212,7 @@ namespace MilestonePSTools
                 if (streamUsage == null) return;
                 if (SupportsSecondaryRecording())
                 {
-                    if (value == streamUsage.RecordTo.Equals(RecordingTrackToId[RecordingTracks.Primary]))
+                    if (value == streamUsage.RecordTo.Equals(RecordingTrackToId[RecordingTracks.Primary], StringComparison.OrdinalIgnoreCase))
                     {
                         return;
                     }
@@ -266,7 +266,7 @@ namespace MilestonePSTools
                     if (streamUsage?.RecordTo.Equals(value, StringComparison.OrdinalIgnoreCase) ?? true) return;
 
                     // If another stream usage is designated the same recording track, set it to None
-                    var otherUsage = FindStreamUsage(u => u.RecordTo == value);
+                    var otherUsage = FindStreamUsage(u => u.RecordTo.Equals(value, StringComparison.OrdinalIgnoreCase));
                     if (otherUsage != null)
                     {
                         otherUsage.RecordTo = RecordingTrackToId[RecordingTracks.None];
@@ -408,7 +408,7 @@ namespace MilestonePSTools
         private StreamUsageChildItem GetStreamUsage()
         {
             return GetStreamDefinition().StreamUsageChildItems
-                    .Where(u => u.StreamReferenceId.Equals(u.StreamReferenceIdValues[Name]))
+                    .Where(u => u.StreamReferenceId.Equals(u.StreamReferenceIdValues[Name], StringComparison.OrdinalIgnoreCase))
                     .FirstOrDefault();
         }
 

--- a/tests/MilestonePSTools/MilestonePSTools.integration.tests.ps1
+++ b/tests/MilestonePSTools/MilestonePSTools.integration.tests.ps1
@@ -4,6 +4,7 @@ if ([string]::IsNullOrWhiteSpace($ModulePath)) {
 }
 Describe 'MilestonePSTools Integration Tests' {
     BeforeDiscovery {
+        $ErrorActionPreference = 'Stop'
         $script:SkipIntegrationTests = $true
         if (-not (Test-Path $ModulePath)) {
             $searchPath = [io.path]::Combine($env:BHProjectPath, 'Output', $env:BHProjectName, "$($env:BHProjectName).psd1")
@@ -32,44 +33,39 @@ Describe 'MilestonePSTools Integration Tests' {
 
         Write-Verbose "SkipReadWriteTests = $script:SkipReadWriteTests"
         Write-Verbose "SkipIntegrationTests = $script:SkipIntegrationTests"
+
+        # This will throw and return false if the vault is locked
+        $null = Test-SecretVault -Name secretstore
+
+        $connectParams = @{
+            ServerAddress = Get-Secret -Vault secretstore -Name MilestonePSTools.Connect.ServerAddress -AsPlainText -ErrorAction Stop
+            Credential    = Get-Secret -Vault secretstore -Name MilestonePSTools.Connect.WindowsCredential -ErrorAction Stop
+            Force         = $true
+            ErrorAction   = 'Stop'
+            AcceptEula    = $true
+        }
+        Connect-ManagementServer @connectParams
     }
 
     Context 'Read-Write Tests' {
         BeforeAll {
-            Write-Host "Read-Write Tests.BeforeAll"
-            $errorPref = $ErrorActionPreference
-            try {
-                $ErrorActionPreference = 'Stop'
-                $ProgressPreference = 'SilentlyContinue'
+            $script:OriginalProgressPreference = $ProgressPreference
+            $global:ProgressPreference = 'SilentlyContinue'
+            $ErrorActionPreference = 'Stop'
 
-                # This will throw and return false if the vault is locked
-                $null = Test-SecretVault -Name secretstore
-
-                $connectParams = @{
-                    ServerAddress = Get-Secret -Vault secretstore -Name MilestonePSTools.Connect.ServerAddress -AsPlainText -ErrorAction Stop
-                    Credential    = Get-Secret -Vault secretstore -Name MilestonePSTools.Connect.WindowsCredential -ErrorAction Stop
-                    Force         = $true
-                    ErrorAction   = 'Stop'
-                    AcceptEula    = $true
-                }
-                Connect-ManagementServer @connectParams
-
-                $recorder = Get-VmsRecordingServer | Select-Object -First 1
-                $recorder | Get-VmsHardware | Remove-Hardware -Confirm:$false
-                $cred = [pscredential]::new('a', ('a' | ConvertTo-SecureString -AsPlainText -Force))
-                $script:StableFpsHardware = $recorder | Add-VmsHardware -HardwareAddress "http://localhost:5000" -Name 'MilestonePSTools.Tests' -DriverNumber 5000 -Credential $cred -Force | ForEach-Object {
-                    $hw = $_
-                    $fileKey = $hw.HardwareDriverSettingsFolder.HardwareDriverSettings[0].HardwareDriverSettingsChildItems[0].GetPropertyKeys() | Where-Object { $_ -match 'VideoH264Files' } | Select-Object -First 1
-                    $file = $hw.HardwareDriverSettingsFolder.HardwareDriverSettings[0].HardwareDriverSettingsChildItems[0].GetValueTypeInfoList($fileKey) | Where-Object Value -ne 'None' | Select-Object -First 1 -ExpandProperty Value
-                    $hw | Set-HardwareSetting -Name 'VideoCodec' -Value 'H264'
-                    $hw | Set-HardwareSetting -Name 'VideoH264Files' -Value $file
-                    $hw
-                }
-                $null = New-VmsDeviceGroup -Path /StableFPS | Add-VmsDeviceGroupMember -Device ($script:StableFpsHardware | Get-VmsCamera -EnableFilter All)
-                Clear-VmsCache
-            } finally {
-                $ErrorActionPreference = $errorPref
+            $recorder = Get-VmsRecordingServer | Select-Object -First 1
+            $recorder | Get-VmsHardware -EnableFilter All | Remove-Hardware -Confirm:$false
+            $cred = [pscredential]::new('a', ('a' | ConvertTo-SecureString -AsPlainText -Force))
+            $script:StableFpsHardware = $recorder | Add-VmsHardware -HardwareAddress "http://localhost:5000" -Name 'MilestonePSTools.Tests' -DriverNumber 5000 -Credential $cred -Force | ForEach-Object {
+                $hw = $_
+                $fileKey = $hw.HardwareDriverSettingsFolder.HardwareDriverSettings[0].HardwareDriverSettingsChildItems[0].GetPropertyKeys() | Where-Object { $_ -match 'VideoH264Files' } | Select-Object -First 1
+                $file = $hw.HardwareDriverSettingsFolder.HardwareDriverSettings[0].HardwareDriverSettingsChildItems[0].GetValueTypeInfoList($fileKey) | Where-Object Value -ne 'None' | Select-Object -First 1 -ExpandProperty Value
+                $hw | Set-HardwareSetting -Name 'VideoCodec' -Value 'H264'
+                $hw | Set-HardwareSetting -Name 'VideoH264Files' -Value $file
+                $hw
             }
+            $null = New-VmsDeviceGroup -Path /StableFPS | Add-VmsDeviceGroupMember -Device ($script:StableFpsHardware | Get-VmsCamera -EnableFilter All)
+            Clear-VmsCache
         }
 
         try {
@@ -95,6 +91,7 @@ Describe 'MilestonePSTools Integration Tests' {
 
         AfterAll {
             Disconnect-ManagementServer
+            $global:ProgressPreference = $script:OriginalProgressPreference
         }
     }
 }

--- a/tests/MilestonePSTools/read-write/Add-VmsHardware.integration.ps1
+++ b/tests/MilestonePSTools/read-write/Add-VmsHardware.integration.ps1
@@ -5,7 +5,7 @@ Context 'Add-VmsHardware' -Skip:($script:SkipReadWriteTests)  {
         try {
             $rec = Get-VmsRecordingServer | Select-Object -First 1
             $address = [uri]('http://{0}' -f $rec.HostName)
-            $rec | Get-VmsHardware | Where-Object { [uri]$_.Address -eq $address } | Remove-Hardware -Confirm:$false
+            $rec | Get-VmsHardware -EnableFilter All | Where-Object { [uri]$_.Address -eq $address } | Remove-Hardware -Confirm:$false
             $cred = [pscredential]::new('a', ('a' | ConvertTo-SecureString -AsPlainText -Force))
             $hw = $rec | Add-VmsHardware -HardwareAddress $address -DriverNumber 421 -Credential $cred
             $hw | Should -Not -BeNullOrEmpty

--- a/tests/MilestonePSTools/read-write/Get-And-Set-VmsDevice.integration.ps1
+++ b/tests/MilestonePSTools/read-write/Get-And-Set-VmsDevice.integration.ps1
@@ -8,7 +8,7 @@ Context 'Read and write device settings' -Skip:($script:SkipReadWriteTests)  {
         try {
             $rec = Get-VmsRecordingServer | Select-Object -First 1
             $address = [uri]('http://{0}' -f $rec.HostName)
-            $rec | Get-VmsHardware | Where-Object { [uri]$_.Address -eq $address } | Remove-Hardware -Confirm:$false
+            $rec | Get-VmsHardware -EnableFilter All | Where-Object { [uri]$_.Address -eq $address } | Remove-Hardware -Confirm:$false
             $cred = [pscredential]::new('a', ('a' | ConvertTo-SecureString -AsPlainText -Force))
             $script:hw = $rec | Add-VmsHardware -HardwareAddress $address -DriverNumber 5000 -Credential $cred -ErrorAction Stop
         } catch {

--- a/tests/MilestonePSTools/read-write/Get-VmsCameraStream.integration.ps1
+++ b/tests/MilestonePSTools/read-write/Get-VmsCameraStream.integration.ps1
@@ -1,6 +1,6 @@
 Context 'Get-VmsCameraStream' -Skip:($script:SkipReadWriteTests) {
     BeforeAll {
-        $script:StableFpsHardware = Get-VmsHardware -Name 'MilestonePSTools.Tests'
+        $script:StableFpsHardware = Get-VmsHardware -Name 'MilestonePSTools.Tests' -EnableFilter All
         $script:streams = $script:StableFpsHardware | Get-VmsCamera | Select-Object -First 1 | Get-VmsCameraStream
     }
 

--- a/tests/MilestonePSTools/read-write/Import-VmsHardware/Import-VmsHardware.integration.ps1
+++ b/tests/MilestonePSTools/read-write/Import-VmsHardware/Import-VmsHardware.integration.ps1
@@ -48,7 +48,7 @@ Context 'Import-VmsHardware' -Skip:($script:SkipReadWriteTests) {
                 UserName     = 'a'
                 Password     = 'a'
                 DriverNumber = '421'
-                DriverFamily = 'Universal'
+                DriverGroup  = 'Universal'
                 Enabled      = 'True'
                 HardwareName = 'Universal Driver (http://127.0.0.1:2001/)'
                 StorageName  = 'Local default'
@@ -63,7 +63,7 @@ Context 'Import-VmsHardware' -Skip:($script:SkipReadWriteTests) {
                 UserName     = 'a'
                 Password     = 'a'
                 DriverNumber = '421'
-                DriverFamily = 'Universal'
+                DriverGroup  = 'Universal'
                 Enabled      = 'False'
                 HardwareName = 'Universal Driver (http://127.0.0.1:2002/)'
                 StorageName  = $script:Storage.Name
@@ -81,7 +81,7 @@ Context 'Import-VmsHardware' -Skip:($script:SkipReadWriteTests) {
                 UserName     = 'a'
                 Password     = 'a'
                 DriverNumber = '421'
-                DriverFamily = 'Universal'
+                DriverGroup  = 'Universal'
                 Enabled      = 'True'
                 HardwareName = 'Universal Driver (http://127.0.0.1:2001/)'
                 StorageName  = 'Local default'
@@ -96,7 +96,7 @@ Context 'Import-VmsHardware' -Skip:($script:SkipReadWriteTests) {
                 UserName     = 'a'
                 Password     = 'a'
                 DriverNumber = '421'
-                DriverFamily = 'Universal'
+                DriverGroup  = 'Universal'
                 Enabled      = 'False'
                 HardwareName = 'Universal Driver (http://127.0.0.1:2002/)'
                 StorageName  = $script:Storage.Name
@@ -173,11 +173,11 @@ Context 'Import-VmsHardware' -Skip:($script:SkipReadWriteTests) {
     #     throw "Test not implemented"
     # }
 
-    # It 'Can import hardware with DriverFamily' {
+    # It 'Can import hardware with DriverGroup' {
     #     throw "Test not implemented"
     # }
 
-    # It 'Can import hardware with out DriverNumber or DriverFamily' {
+    # It 'Can import hardware with out DriverNumber or DriverGroup' {
     #     throw "Test not implemented"
     # }
 

--- a/tests/MilestonePSTools/read-write/RestrictedMedia.integration.ps1
+++ b/tests/MilestonePSTools/read-write/RestrictedMedia.integration.ps1
@@ -1,4 +1,4 @@
-Context 'Restricted Media' -Skip:($script:SkipReadWriteTests) {
+Context 'Restricted Media' -Skip:($script:SkipReadWriteTests -or -not (Test-VmsLicensedFeature -Name RestrictedMedia)) {
     BeforeAll {
         $script:RestrictedMediaPrefix = 'PESTER'
         Get-VmsRestrictedMedia -Live | Remove-VmsRestrictedMedia -Confirm:$false

--- a/tests/MilestonePSTools/read-write/Roles/Set-VmsRoleOverallSecurity.integration.ps1
+++ b/tests/MilestonePSTools/read-write/Roles/Set-VmsRoleOverallSecurity.integration.ps1
@@ -43,7 +43,7 @@ Context 'Set-VmsRoleOverallSecurity' -Skip:($script:SkipReadWriteTests) {
         $cameras = $script:role | Get-VmsRoleOverallSecurity -SecurityNamespace Cameras
         $namespaceName = 'Cameras'
         $key = 'GENERIC_WRITE'
-        $newValue = if ($cameras[$key] -eq 'None') { 'Allow' } else { 'None' }
+        $newValue = if ($cameras[$key] -ne 'Allow') { 'Allow' } else { 'None' }
         $script:role | Set-VmsRoleOverallSecurity -SecurityNamespace $namespaceName -Permissions (@{"$key" = $newValue})
 
         ($script:role | Get-VmsRoleOverallSecurity -SecurityNamespace $namespaceName).$key | Should -Be $newValue

--- a/tests/MilestonePSTools/read-write/Set-VmsCameraStream.integration.ps1
+++ b/tests/MilestonePSTools/read-write/Set-VmsCameraStream.integration.ps1
@@ -1,6 +1,6 @@
 Context 'Set-VmsCameraStream' -Skip:($script:SkipReadWriteTests) {
     BeforeAll {
-        $script:StableFpsHardware = Get-VmsHardware -Name 'MilestonePSTools.Tests'
+        $script:StableFpsHardware = Get-VmsHardware -Name 'MilestonePSTools.Tests' -EnableFilter All
         $script:streams = $script:StableFpsHardware | Get-VmsCamera -Channel 0 | Get-VmsCameraStream
         $stream1 = $script:streams | Select-Object -First 1
         $splat = @{
@@ -118,5 +118,40 @@ Context 'Set-VmsCameraStream' -Skip:($script:SkipReadWriteTests) {
         }
 
         $streams | Set-VmsCameraStream -Settings @{ Resolution = $oldResolution }
+    }
+
+    It 'Can change Primary stream using deprecated Recorded switch' {
+        $camera = $script:StableFpsHardware | Get-VmsCamera -Channel 0
+        $streams = $camera | Get-VmsCameraStream
+        $oldPrimaryStream = $streams | Where-Object Recorded | Select-Object -First 1
+        $targetStream = $streams | Where-Object Name -NE $oldPrimaryStream.Name | Select-Object -First 1
+
+        $oldPrimaryStream | Should -Not -BeNullOrEmpty
+        $targetStream | Should -Not -BeNullOrEmpty -Because 'This test requires another stream to promote to Primary.'
+
+        $targetStream | Set-VmsCameraStream -Recorded -ErrorAction Stop
+
+        foreach ($round in 1..2) {
+            # Check local "live" results first, then clear cache
+            # and pull current values from management server to
+            # verify they were also correctly set there.
+            if ($round -eq 2) {
+                $camera.ClearChildrenCache()
+                $streams = $camera | Get-VmsCameraStream
+                $oldPrimaryStream = $streams | Where-Object Name -EQ $oldPrimaryStream.Name
+                $targetStream = $streams | Where-Object Name -EQ $targetStream.Name
+            }
+
+            $targetStream.Recorded | Should -BeTrue
+            $oldPrimaryStream.Recorded | Should -BeFalse
+            ($streams | Where-Object Recorded).Count | Should -Be 1
+
+            if (Test-VmsLicensedFeature -Name MultistreamRecording) {
+                $targetStream.RecordingTrackName | Should -Be 'Primary'
+                $targetStream.PlaybackDefault | Should -BeTrue
+                $oldPrimaryStream.RecordingTrackName | Should -Be 'None'
+                $oldPrimaryStream.PlaybackDefault | Should -BeFalse
+            }
+        }
     }
 }

--- a/tests/MilestonePSTools/read-write/Set-VmsCameraStream.integration.ps1
+++ b/tests/MilestonePSTools/read-write/Set-VmsCameraStream.integration.ps1
@@ -3,7 +3,16 @@ Context 'Set-VmsCameraStream' -Skip:($script:SkipReadWriteTests) {
         $script:StableFpsHardware = Get-VmsHardware -Name 'MilestonePSTools.Tests'
         $script:streams = $script:StableFpsHardware | Get-VmsCamera -Channel 0 | Get-VmsCameraStream
         $stream1 = $script:streams | Select-Object -First 1
-        $stream1 | Set-VmsCameraStream -RecordingTrack Primary -PlaybackDefault -LiveDefault -LiveMode WhenNeeded -DisplayName $stream1.Name
+        $splat = @{
+            RecordingTrack  = 'Primary'
+            LiveDefault     = $true
+            LiveMode        = 'WhenNeeded'
+            DisplayName     = $stream1.Name
+        }
+        if (Test-VmsLicensedFeature -Name MultistreamRecording) {
+            $splat.PlaybackDefault = $true
+        }
+        $stream1 | Set-VmsCameraStream @splat
         $script:streams | Select-Object -Skip 1 | Set-VmsCameraStream -Disabled
     }
 
@@ -55,7 +64,16 @@ Context 'Set-VmsCameraStream' -Skip:($script:SkipReadWriteTests) {
         $oldLiveStream.LiveDefault | Should -BeFalse
 
         # Cleanup
-        $oldLiveStream | Set-VmsCameraStream -LiveDefault -RecordingTrack Primary -PlaybackDefault -LiveMode WhenNeeded -ErrorAction Stop
+        $splat = @{
+            LiveDefault     = $true
+            RecordingTrack  = 'Primary'
+            LiveMode        = 'WhenNeeded'
+            ErrorAction     = 'Stop'
+        }
+        if (Test-VmsLicensedFeature -Name MultistreamRecording) {
+            $splat.PlaybackDefault = $true
+        }
+        $oldLiveStream | Set-VmsCameraStream @splat
         $stream | Set-VmsCameraStream -Disabled -ErrorAction Stop
     }
 
@@ -69,7 +87,13 @@ Context 'Set-VmsCameraStream' -Skip:($script:SkipReadWriteTests) {
             ($camera | Get-VmsCameraStream | Where-Object Enabled -EQ $false).Count | Should -Be 0 -Because 'All streams should be enabled with LiveMode "WhenNeeded"'
 
         # Disable all streams except one
-        $camera | Get-VmsCameraStream -LiveDefault | Set-VmsCameraStream -RecordingTrack Primary -PlaybackDefault
+        $splat = @{
+             RecordingTrack = 'Primary'
+        }
+        if (Test-VmsLicensedFeature -Name MultistreamRecording) {
+            $splat.PlaybackDefault = $true
+        }
+        $camera | Get-VmsCameraStream -LiveDefault | Set-VmsCameraStream @splat
         $camera | Get-VmsCameraStream | Where-Object LiveDefault -EQ $false | Set-VmsCameraStream -Disabled
             ($camera | Get-VmsCameraStream -Enabled).Count | Should -Be 1
     }

--- a/tests/MilestonePSTools/read-write/Set-VmsHardware.integration.ps1
+++ b/tests/MilestonePSTools/read-write/Set-VmsHardware.integration.ps1
@@ -37,6 +37,15 @@ Context 'Set-VmsHardware' -Skip:($script:SkipReadWriteTests) {
 
         # Update the hardware, check all properties, then clear cache and get a fresh
         # copy from the management server and check all properties again.
+        if ([version](Get-VmsManagementServer).Version -lt [version]'23.2') {
+            $assert = @{
+                 Throw         = $true
+                 ExceptionType = [System.Management.Automation.ParameterBindingException]
+                 Because       = 'UpdateRemoteHardware requires VMS version 2023 R2 or greater'
+            }
+            { Set-VmsHardware @hwParams } | Should @assert
+            $hwParams.Remove('UpdateRemoteHardware')
+        }
         $updatedHw = Set-VmsHardware @hwParams
         for ($i = 0; $i -lt 2; $i++) {
             $updatedHw.Enabled | Should -Be $hwParams.Enabled

--- a/tests/MilestonePSTools/read-write/Set-VmsLoginProvider.integration.ps1
+++ b/tests/MilestonePSTools/read-write/Set-VmsLoginProvider.integration.ps1
@@ -40,11 +40,8 @@ Context 'Set-VmsLoginProvider' -Skip:($script:SkipReadWriteTests) {
             $updatedProvider = $provider | Set-VmsLoginProvider @newParams
             Clear-VmsCache
             $updatedProvider = Get-VmsLoginProvider -Name $newParams.Name
-            if ([version](Get-VmsManagementServer).Version -ge 23.1) {
-                $updatedProvider.ClientSecretHasValue | Should -BeTrue
-            } else {
-                $updatedProvider.ClientSecret | Should -BeExactly $newParams.ClientSecret
-            }
+            
+            $updatedProvider.ClientSecretHasValue | Should -BeTrue
             $updatedProvider.PromptForLogin | Should -BeFalse
             $updatedProvider.UserNameClaimType | Should -BeExactly $newParams.UserNameClaim
             $newParams.Scopes | Foreach-Object {


### PR DESCRIPTION
Fixes #184 where `Get-VmsCameraReport` returns empty values for the `ConfiguredRecordedResolution`, `ConfiguredRecordedCodec`, and `ConfiguredRecordedFPS` columns.

## Description
In XProtect VMS versions older than 2023 R2, only one stream could be recorded. Improvements to the `Get-VmsCameraStream` and `Set-VmsCameraStream` cmdlets to support the MultistreamRecording feature made false assumptions about how the MIP SDK represented the stream usages when connected to older versions without support for Primary and Secondary recorded streams.

As a result, the output from `Get-VmsCameraStream` looked like this, and the empty values for `RecordingTrackName` resulted in the camera report showing empty values for the `ConfiguredRecorded*` columns.

| DisplayName    | Enabled | LiveMode   | LiveDefault | Recorded | RecordingTrackName | PlaybackDefault |
|----------------|---------|------------|-------------|----------|--------------------|-----------------|
| Video stream 1 | True    | WhenNeeded | True        |          | None               | False           |
| Video stream 1 | True    | WhenNeeded | True        |          | None               | False           |
| Video stream 1 | True    | WhenNeeded | True        |          | None               | False           |
| Video stream 1 | True    | WhenNeeded | True        |          | None               | False           |


## Related Issue

Issue #184 

## How Has This Been Tested?

Tested against XProtect 2022 R3 manually and by running integration tests with `.\build.ps1 -task integration-tests`. There are unrelated tests that fail as a result of other features not available on that version, and those tests should be updated in the future so that they're skipped when the feature isn't available on the target VMS.
