### PR TITLE
Add certificate-based authentication support for Login Providers

### DIFF
--- a/MilestonePSTools/Private/InvokeVmsRestApi.ps1
+++ b/MilestonePSTools/Private/InvokeVmsRestApi.ps1
@@ -1,0 +1,110 @@
+# Copyright 2026 Milestone Systems A/S
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+function InvokeVmsRestApi {
+    <#
+    .SYNOPSIS
+    Invokes an authenticated request against the XProtect API Gateway REST endpoint.
+
+    .DESCRIPTION
+    InvokeVmsRestApi is an internal helper that sends HTTP requests to Milestone's
+    XProtect API Gateway REST API under the /rest/v1 route. It resolves the API
+    Gateway URI from the registered services for the active site, adds a bearer
+    authorization header from the current login token cache, and returns the
+    deserialized response. When a dictionary body is supplied it is serialized to
+    JSON before sending.
+
+    .PARAMETER Method
+    Specifies the HTTP method used for the request. The default is Get.
+
+    .PARAMETER Body
+    Specifies the payload to send with methods that accept a request body. A
+    dictionary/hashtable is converted to JSON with depth 10 before transmission.
+
+    .PARAMETER ContentType
+    Specifies the Content-Type header value to use when Body is present. The
+    default is application/json.
+
+    .PARAMETER ResourcePath
+    Specifies the relative API resource path under /rest/v1, for example
+    'loginproviders' or 'loginproviders/{id}'.
+
+    .PARAMETER GatewayUri
+    Specifies the base URI of the API Gateway service. If omitted, the function
+    discovers the gateway URI from the registered services for the active site.
+
+    .EXAMPLE
+    InvokeVmsRestApi -ResourcePath 'loginproviders'
+
+    Retrieves the collection of login providers from the registered API Gateway
+    for the current site.
+
+    .NOTES
+    Requires a valid login token from (Get-LoginSettings).IdentityTokenCache.
+    #>
+    [CmdletBinding()]
+    param (
+        [Parameter()]
+        [string]
+        $Method = 'Get',
+
+        [Parameter()]
+        [object]
+        $Body,
+
+        [Parameter()]
+        [string]
+        $ContentType = 'application/json',
+
+        [Parameter(Mandatory)]
+        [Alias('Path')]
+        [string]
+        $ResourcePath,
+
+        [Parameter()]
+        [uri]
+        $GatewayUri
+    )
+
+    begin {
+        Assert-VmsRequirementsMet
+        if (-not $MyInvocation.BoundParameters.ContainsKey('GatewayUri')) {
+            $GatewayUri = (Get-RegisteredService -ServiceType 'e46b7bf9-03ce-44eb-bbdc-8ba16d0aaa80').UriArray | Select-Object -First 1
+        }
+        if ($null -eq $GatewayUri) {
+            throw "No 'API Gateway Service' registered on site $((Get-VmsSite).Name)."
+        }
+    }
+
+    process {
+        $uriBuilder = [uribuilder]$GatewayUri
+        $uriBuilder.Path = $uriBuilder.Path.TrimEnd('/') + '/rest/v1/' + $ResourcePath
+        $requestParams = @{
+            Uri     = $uriBuilder.Uri
+            Method  = $Method
+            Headers = @{
+                Authorization = "Bearer $((Get-LoginSettings).IdentityTokenCache.Token)"
+            }
+        }
+        if ($MyInvocation.BoundParameters.ContainsKey('Body')) {
+            $requestParams.ContentType = $ContentType
+            if ($Body -is [System.Collections.IDictionary]) {
+                $requestParams.Body = [pscustomobject]$Body | ConvertTo-Json -Depth 10
+            } else {
+                $requestParams.Body = $Body.ToString()
+            }
+        }
+        Invoke-RestMethod @requestParams
+    }
+}

--- a/MilestonePSTools/Private/InvokeVmsRestApi.ps1
+++ b/MilestonePSTools/Private/InvokeVmsRestApi.ps1
@@ -89,7 +89,7 @@ function InvokeVmsRestApi {
 
     process {
         $uriBuilder = [uribuilder]$GatewayUri
-        $uriBuilder.Path = $uriBuilder.Path.TrimEnd('/') + '/rest/v1/' + $ResourcePath
+        $uriBuilder.Path = $uriBuilder.Path.TrimEnd('/') + '/rest/v1/' + $ResourcePath.TrimStart('/')
         $requestParams = @{
             Uri     = $uriBuilder.Uri
             Method  = $Method

--- a/MilestonePSTools/Public/New-VmsLoginProvider.ps1
+++ b/MilestonePSTools/Public/New-VmsLoginProvider.ps1
@@ -32,6 +32,12 @@ function New-VmsLoginProvider {
         $ClientSecret,
 
         [Parameter()]
+        [ValidateVmsVersion('25.3')]
+        [ValidateSet('SharedSecret', 'X509Thumbprint')]
+        [string]
+        $ClientSecretType = 'SharedSecret',
+
+        [Parameter()]
         [string]
         $CallbackPath = '/signin-oidc',
 
@@ -64,9 +70,31 @@ function New-VmsLoginProvider {
     process {
         try {
             $credential = [pscredential]::new($ClientId, $ClientSecret)
-            $folder = (Get-VmsManagementServer).LoginProviderFolder
-            $serverTask = $folder.AddLoginProvider([guid]::Empty, $Name, $ClientId, $credential.GetNetworkCredential().Password, $CallbackPath, $Authority, $UserNameClaim, $Scopes, $PromptForLogin, $Enabled)
-            $loginProvider = Get-VmsLoginProvider | Where-Object Path -eq $serverTask.Path
+            if ($ClientSecretType -eq 'X509Thumbprint') {
+                # The .NET SDK's AddLoginProvider method does not support the
+                # clientSecretType field, so certificate-based authentication must
+                # be configured directly against the API Gateway REST endpoint.
+                $loginProviderBody = @{
+                    name              = $Name
+                    clientId          = $ClientId
+                    clientSecret      = $credential.GetNetworkCredential().Password
+                    clientSecretType  = $ClientSecretType
+                    authority         = $Authority
+                    callbackPath      = $CallbackPath
+                    scopes            = $Scopes
+                    userNameClaimType = $UserNameClaim
+                    promptForLogin    = $PromptForLogin
+                    enabled           = $Enabled
+                }
+                $null = InvokeVmsRestApi -ResourcePath 'loginproviders' -Method 'POST' -Body $loginProviderBody
+                $folder = (Get-VmsManagementServer).LoginProviderFolder
+                $folder.ClearChildrenCache()
+                $loginProvider = Get-VmsLoginProvider -Name $Name
+            } else {
+                $folder = (Get-VmsManagementServer).LoginProviderFolder
+                $serverTask = $folder.AddLoginProvider([guid]::Empty, $Name, $ClientId, $credential.GetNetworkCredential().Password, $CallbackPath, $Authority, $UserNameClaim, $Scopes, $PromptForLogin, $Enabled)
+                $loginProvider = Get-VmsLoginProvider | Where-Object Path -eq $serverTask.Path
+            }
             if ($null -ne $loginProvider) {
                 $loginProvider
             }

--- a/MilestonePSTools/Public/New-VmsLoginProvider.ps1
+++ b/MilestonePSTools/Public/New-VmsLoginProvider.ps1
@@ -35,7 +35,7 @@ function New-VmsLoginProvider {
         [ValidateVmsVersion('25.3')]
         [ValidateSet('SharedSecret', 'X509Thumbprint')]
         [string]
-        $ClientSecretType = 'SharedSecret',
+        $ClientSecretType,
 
         [Parameter()]
         [string]

--- a/MilestonePSTools/Public/Set-VmsLoginProvider.ps1
+++ b/MilestonePSTools/Public/Set-VmsLoginProvider.ps1
@@ -38,6 +38,12 @@ function Set-VmsLoginProvider {
         $ClientSecret,
 
         [Parameter()]
+        [ValidateVmsVersion('25.3')]
+        [ValidateSet('SharedSecret', 'X509Thumbprint')]
+        [string]
+        $ClientSecretType,
+
+        [Parameter()]
         [string]
         $CallbackPath,
 
@@ -96,11 +102,15 @@ function Set-VmsLoginProvider {
                             }
                             $dirty = $true
                         }
-                    } elseif ($key -eq 'ClientSecret') {
+                    } elseif ($key -eq 'ClientSecret' -and $ClientSecretType -ne 'X509Thumbprint') {
                         Write-Verbose "Updating $key on login provider '$initialName'"
                         $cred = [pscredential]::new('a', $ClientSecret)
                         $LoginProvider.ClientSecret = $cred.GetNetworkCredential().Password
                         $dirty = $true
+                    } elseif ($key -eq 'ClientSecret' -and $ClientSecretType -eq 'X509Thumbprint') {
+                        # The secret carries a certificate thumbprint and is applied
+                        # via the API Gateway below, not through the .NET SDK, so that
+                        # clientSecretType can be set to X509Thumbprint.
                     } elseif ($key -eq 'Enabled' -and $LoginProvider.Enabled -ne $Enabled) {
                         Write-Verbose "Setting Enabled to $Enabled on login provider '$initialName'"
                         $LoginProvider.Enabled = $Enabled
@@ -117,8 +127,26 @@ function Set-VmsLoginProvider {
                 }
                 if ($dirty) {
                     $LoginProvider.Save()
-                } else {
+                } elseif ($ClientSecretType -ne 'X509Thumbprint') {
                     Write-Verbose "No changes were made to login provider '$initialName'."
+                }
+
+                if ($ClientSecretType -eq 'X509Thumbprint') {
+                    if (-not $MyInvocation.BoundParameters.ContainsKey('ClientSecret')) {
+                        throw "The ClientSecret parameter is required when ClientSecretType is 'X509Thumbprint'. Provide the certificate thumbprint as the ClientSecret value."
+                    }
+                    # The .NET SDK does not support the clientSecretType field, so
+                    # certificate-based authentication is configured directly against
+                    # the API Gateway REST endpoint.
+                    Write-Verbose "Updating ClientSecret and ClientSecretType on login provider '$initialName' via the API Gateway"
+                    $cred = [pscredential]::new('a', $ClientSecret)
+                    $loginProviderBody = @{
+                        clientSecret     = $cred.GetNetworkCredential().Password
+                        clientSecretType = $ClientSecretType
+                    }
+                    $null = InvokeVmsRestApi -ResourcePath "loginproviders/$($LoginProvider.Id)" -Method 'PATCH' -Body $loginProviderBody
+                    (Get-VmsManagementServer).LoginProviderFolder.ClearChildrenCache()
+                    $LoginProvider = Get-VmsLoginProvider -Name $LoginProvider.Name
                 }
             }
 

--- a/MilestonePSTools/Public/Set-VmsLoginProvider.ps1
+++ b/MilestonePSTools/Public/Set-VmsLoginProvider.ps1
@@ -107,7 +107,7 @@ function Set-VmsLoginProvider {
                         $cred = [pscredential]::new('a', $ClientSecret)
                         $LoginProvider.ClientSecret = $cred.GetNetworkCredential().Password
                         $dirty = $true
-                    } elseif ($key -eq 'ClientSecret' -and $ClientSecretType -eq 'X509Thumbprint') {
+                    } elseif ($key -eq 'ClientSecretType') {
                         # The secret carries a certificate thumbprint and is applied
                         # via the API Gateway below, not through the .NET SDK, so that
                         # clientSecretType can be set to X509Thumbprint.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,16 @@ hide:
 
 ## [vNext] unreleased
 
+### ✨ Added
+
+- **`New-VmsLoginProvider`** and **`Set-VmsLoginProvider`** now accept a `-ClientSecretType` parameter with the values
+  `SharedSecret` (default) and `X509Thumbprint`. When `X509Thumbprint` is specified, the `-ClientSecret` value is
+  interpreted as a certificate thumbprint and the external login provider is configured for certificate-based (OIDC
+  `private_key_jwt`) authentication. Because the .NET SDK does not expose this field, the cmdlets transparently
+  configure the provider through the XProtect API Gateway. Requires XProtect 2025 R3 or later, and the certificate's
+  private key must be available to the identity server. Note that editing the secret in the Management Client UI
+  reverts the provider to `SharedSecret`.
+
 ## [25.2.61] 2026-05-14
 
 ### 🔄 Changed
@@ -99,7 +109,7 @@ hide:
 
 ## [25.2.6] 2025-06-18
 
-### ➕ Added
+### ✨ Added
 
 - Added support for `Hardware` on the `Get-VmsDeviceGeneralSetting` and `Set-VmsDeviceGeneralSetting` commands, with new
   aliases -- `Get-VmsHardwareGeneralSetting` and `Set-VmsHardwareGeneralSetting`.
@@ -119,7 +129,7 @@ hide:
 
 ## [25.1.50] 2025-06-06
 
-### ➕ Added
+### ✨ Added
 
 - If [telemetry](./commands/en-US/about_Telemetry.md) is enabled, the use of any MilestonePSTools command will be
   reported to Azure Application Insights once per PowerShell session. The name of the command used, and the name of the
@@ -209,7 +219,7 @@ hide:
   This has been fixed by making an empty array the default value for `-Scopes`.
 - Fixed `SmartMap` parameter on `New-VmsAlarmDefinition` and `Set-VmsAlarmDefinition`.
 
-### ➕ Added
+### ✨ Added
 
 - The new commands `Get-VmsDeviceGeneralSetting`, and `Set-VmsDeviceGeneralSetting`, will deprecate all the
   device-specific commands like `Get-MicrophoneSetting` and `Set-SpeakerSetting` for accessing and modifying
@@ -259,13 +269,13 @@ hide:
 
 ## [24.2.12] 2025-01-29
 
-### ➕ Added
+### ✨ Added
 
 - New commands for creating and managing alarm definitions: `New-VmsAlarmDefinition`, `Get-VmsAlarmDefinition`, `Set-VmsAlarmDefinition` and `Remove-VmsAlarmDefinition`.
 
 ## [24.2.1] 2024-11-09
 
-### ➕ Added
+### ✨ Added
 
 - Added commands for creating, getting, and removing `TrustedIssuer` records to support the use of external identity
   providers for single sign-on to a Milestone Federated Architecture (MFA) hierarchy.
@@ -287,7 +297,7 @@ hide:
 
 ## [24.1.27] 2024-09-26
 
-### ➕ Added
+### ✨ Added
 
 - Added a set of commands for creating, updating, and removing live and recorded video restrictions. The associated
   commands can be listed using `Get-Command -Noun VmsRestricted*`.
@@ -311,7 +321,7 @@ hide:
 
 ## [24.1.6] 2024-08-02
 
-### ➕ Added
+### ✨ Added
 
 - `Get-VmsDevice` and `Set-VmsDevice` is a generic form of the `Get-VmsCamera`, `Get-VmsMicrophone`, and similar
   commands. When you want to modify all child devices of one or more `Hardware` objects, for example when performing
@@ -335,7 +345,7 @@ hide:
   displayed on import if you have this option enabled in your environment. The warning provides the commands needed to
   disable it.
 
-### ➕ Added
+### ✨ Added
 
 - `Get-Vms*` and `Set-Vms*` commands have been added for all device types including **Cameras**, **Microphones**,
   **Speakers**, **Metadata**, **Inputs**, and **Outputs**. The original `Get-<devicetype>` commands are now aliases to
@@ -353,7 +363,7 @@ hide:
 - Telemetry is now enabled and sent to Milestone through Azure Application Insights by default. Documentation, including
   instructions for disabling telemetry, can be found in the [about_Telemetry](./commands/en-US/about_Telemetry.md) topic.
 
-### ➕ Added
+### ✨ Added
 
 - `Get-VmsMetadataLiveRecord` and `Get-VmsMetadataRecord` are now available for retrieving live, and recorded metadata
   respectively. Metadata is typically received and stored in the form of an XML document, and due to the wide variety of
@@ -362,7 +372,7 @@ hide:
 
 ## [23.3.42] 2024-06-10
 
-### ➕ Added
+### ✨ Added
 
 - Support for Azure Application Insights telemetry has been introduced but is disabled by default in this release. In
   a future release it may be enabled by default.
@@ -373,7 +383,7 @@ hide:
 
 - `Get-VmsCameraReport` now correctly returns `$true` for the value of `PrivacyMaskEnabled` if a privacy mask is set.
 
-### ➕ Added
+### ✨ Added
 
 - `Set-VmsDeviceStorage` for assigning **Camera**, **Microphone**, **Speaker**, and **Metadata** devices to different
   storage profiles on the same recording server. Assignments can be made by display name, so if you have many recording
@@ -414,7 +424,7 @@ hide:
 
 ## [23.3.2] 2024-02-22
 
-### ➕ Added
+### ✨ Added
 
 - `Get-VmsIServiceRegistrationService` has been added to offer easy access to the ServiceRegistrationService on the management server.
 - The [installation docs](./help/compatibility.md) now include a compatibility table showing the most recent MilestonePSTools versions that should be compatible with different XProtect VMS releases, along with an indication of which combinations are supported. Generally speaking, as long as the XProtect version you connect to is not discontinued according to the official product lifecycle page, the latest MilestonePSTools release is supported for use with that VMS version.
@@ -429,7 +439,7 @@ hide:
 
 ## [23.3.1] 2023-11-17
 
-### ➕ Added
+### ✨ Added
 
 - New `[MilestonePSTools.RequiresInteractiveSession()]` attribute for commands and parameters that should only be used
   in an interactive PowerShell session. Using the `Select-Camera`, or `Select-VideoOSItem` commands, or the `-ShowDialog` parameters on `Connect-Vms` and `Connect-ManagementServer` will now throw an exception when used in a non-interactive
@@ -451,7 +461,7 @@ hide:
 
 ## [23.2.3] 2023-10-11
 
-### ➕ Added
+### ✨ Added
 
 - New `Move-VmsHardware` command can be used to move hardware between recording servers on the same management server.
 - Change passwords on supported hardware devices with `Set-VmsHardware` and the `Password` parameter by including the `-UpdateRemoteHardware` switch.
@@ -490,7 +500,7 @@ hide:
 
 ## [23.2.2] 2023-09-28
 
-### ➕ Added
+### ✨ Added
 
 - New cmdlets for managing webhooks on VMS versions 2023 R1 and later: `New-VmsWebhook`, `Get-VmsWebhook`, `Set-VmsWebhook`, and `Remove-VmsWebhook`.
 - New `Connect-Vms`, `Disconnect-Vms`, and related connection profile cmdlets `Get|Set|Remove-VmsConnectionProfile` which together introduce a new way of managing MilestonePSTools connections. When using `Connect-Vms` without parameters, or when using only the 'Name' parameter, the default, or named connection profile will be used to login to the associated VMS. Or, if no connection profile has been created yet, you will be prompted for credentials. Afterward, the login information will be persisted to disk using `Export-CliXml` which will encrypt the provided credentials using CurrentUser scope in your local appdata directory.When using MilestonePSTools with automation via scheduled tasks or other means of launching scripts on event/schedule, this greatly simplifies things by eliminating the need to figure out credential management every time.
@@ -543,7 +553,7 @@ hide:
   module should work on both 2023 R2 as well as older versions without breaking changes. However,
   you will not be able to use `-RecordingTrack Secondary` on versions older than 2023 R2.
 
-### ➕ Added
+### ✨ Added
 
 - New VmsFailoverGroup and VmsFailoverRecorder cmdlets for managing failover
   recording server groups, assigning failover recording servers to groups, or
@@ -562,7 +572,7 @@ hide:
 
 ## [23.1.3] 2023-04-20
 
-### ➕ Added
+### ✨ Added
 
 - New VmsRule cmdlets for working with Milestone VMS rules. Please see the cmdlet
   documentation for more information. A more detailed guide will be written in
@@ -597,7 +607,7 @@ hide:
 
 ## [23.1.2] 2023-04-07
 
-### ➕ Added
+### ✨ Added
 
 - Suite of nine new smart client profile cmdlets with nouns starting with 'VmsClientProfile'.
   The new cmdlets simplify adding, removing, updating, re-prioritizing, exporting, and importing
@@ -634,7 +644,7 @@ hide:
 
 ## [23.1.1] 2023-03-28
 
-### ➕ Added
+### ✨ Added
 
 - New "VmsBasicUser" and "VmsBasicUserClaim" cmdlets for managing all aspects of basic users, including
   basic user entries created for users who have logged in using an external
@@ -664,7 +674,7 @@ hide:
 
 ## [22.3.1] 2023-02-09
 
-### ➕ Added
+### ✨ Added
 
 - Introduced `Set-VmsHardwareDriver` which can be used to perform a "hardware
   replacement" on XProtect VMS versions 2023 R1 and later. This is an exciting
@@ -769,7 +779,7 @@ parameters.
 | Get-User                       | Removed | Now aliased to Get-VmsRoleMember        |
 | Remove-User                    | Removed | Now aliased to Remove-VmsRoleMember     |
 
-### ➕ Added
+### ✨ Added
 
 - New `VmsDeviceGroup*` cmdlets for adding, removing, and changing device groups and device group members for all device types.
 - New `VmsRole*` cmdlets for getting, adding, setting, and removing roles, role members, and overall security permissions.
@@ -830,7 +840,7 @@ parameters.
 - Fixed an uncommon issue with `Get-VmsCameraReport` where the error `Cannot index into a null array` is returned
   when at least one camera lacks any stream settings in the Settings tab for the camera in Smart Client.
 
-### ➕ Added
+### ✨ Added
 
 - New cmdlets for getting, setting, and clearing site information properties like company name, address, and contact information.
   - Get-VmsSiteInfo
@@ -849,7 +859,7 @@ parameters.
 - Fixed an error in `Get-VmsCameraReport` where cameras without multi-stream support would result in errors being passed to the pipeline.
 - Fixed an error in `Get-VmsCameraReport` where recording servers without cameras could cause an error when using the `-IncludeRetentionInfo` switch.
 
-### ➕ Added
+### ✨ Added
 
 - Several cmdlets for working with ViewGroup and View objects, including cmdlets for copying, exporting, and importing ViewGroups, and modifying permissions.
   - Clear-VmsView
@@ -874,7 +884,7 @@ parameters.
 
 ## [21.2.6] 2022-02-08
 
-### ➕ Added
+### ✨ Added
 
 - `Clear-VmsCache` can be used to clear the child items from the cached
   ManagementServer object (see the caching reference in changes below). This will
@@ -906,7 +916,7 @@ parameters.
 
 ## [21.2.5] 2022-01-27
 
-### ➕ Added
+### ✨ Added
 
 - `Get-VmsDeviceStatus` offers very fast streaming device status information
   through the use of the MIP SDK RecorderStatusService2 API and the
@@ -921,7 +931,7 @@ parameters.
 
 ## [21.2.3] 2022-01-20
 
-### ➕ Added
+### ✨ Added
 
 - Spanish language translations.
 - `Get-VmsCamera` replaced `Get-Camera` and adds the ability to search by name.
@@ -953,7 +963,7 @@ parameters.
 
 ## [21.2.2] 2021-11-04
 
-### ➕ Added
+### ✨ Added
 
 - `New-VmsFailoverGroup`, `Get-VmsFailoverGroup`, and `Remove-VmsFailoverGroup`
   which is supported for XProtect Expert and XProtect Corporate 2021 R2 and
@@ -985,7 +995,7 @@ parameters.
 
 ## [21.2.0] 2021-10-27
 
-### ➕ Added
+### ✨ Added
 
 - Support for `Get-Help -Online`
 - Get-VmsCameraReport as a faster, more reliable replacement for Get-CameraReport.

--- a/docs/commands/command-history.json
+++ b/docs/commands/command-history.json
@@ -1,12 +1,12 @@
 {
-    "Date":  "\/Date(1769800928428)\/",
+    "Date":  "\/Date(1782857404452)\/",
     "Commands":  [
                      {
                          "Aliases":  "",
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-GenericEvent",
                          "VersionAdded":  "1.0.30",
-                         "DatePublished":  "\/Date(1557818250000)\/",
+                         "DatePublished":  "\/Date(1557814650000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -36,9 +36,9 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Set-ManagementServerConfig",
                          "VersionAdded":  "1.0.80",
-                         "DatePublished":  "\/Date(1600310905000)\/",
+                         "DatePublished":  "\/Date(1600307305000)\/",
                          "VersionRemoved":  "1.1.5",
-                         "DateRemoved":  "\/Date(1622709061000)\/",
+                         "DateRemoved":  "\/Date(1622705461000)\/",
                          "AliasedTo":  null
                      },
                      {
@@ -46,7 +46,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Remove-VmsFailoverRecorder",
                          "VersionAdded":  "23.2.1",
-                         "DatePublished":  "\/Date(1692271583000)\/",
+                         "DatePublished":  "\/Date(1692267983000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -56,7 +56,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Set-VmsOutput",
                          "VersionAdded":  "24.1.5",
-                         "DatePublished":  "\/Date(1719908403000)\/",
+                         "DatePublished":  "\/Date(1719904803000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -68,7 +68,7 @@
                          "VersionAdded":  "1.0.69",
                          "DatePublished":  "\/Date(1576051327000)\/",
                          "VersionRemoved":  "1.1.4",
-                         "DateRemoved":  "\/Date(1622306412000)\/",
+                         "DateRemoved":  "\/Date(1622302812000)\/",
                          "AliasedTo":  null
                      },
                      {
@@ -76,9 +76,9 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-TestCmdlet",
                          "VersionAdded":  "1.0.12",
-                         "DatePublished":  "\/Date(1556086129000)\/",
+                         "DatePublished":  "\/Date(1556082529000)\/",
                          "VersionRemoved":  "1.0.13",
-                         "DateRemoved":  "\/Date(1556200603000)\/",
+                         "DateRemoved":  "\/Date(1556197003000)\/",
                          "AliasedTo":  null
                      },
                      {
@@ -96,7 +96,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Set-VmsDevice",
                          "VersionAdded":  "24.1.6",
-                         "DatePublished":  "\/Date(1722676980000)\/",
+                         "DatePublished":  "\/Date(1722673380000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -106,7 +106,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-Kind",
                          "VersionAdded":  "1.0.47",
-                         "DatePublished":  "\/Date(1563626225000)\/",
+                         "DatePublished":  "\/Date(1563622625000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -116,7 +116,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Set-OutputSetting",
                          "VersionAdded":  "1.0.10",
-                         "DatePublished":  "\/Date(1555658225000)\/",
+                         "DatePublished":  "\/Date(1555654625000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -126,7 +126,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Invoke-Method",
                          "VersionAdded":  "1.0.31",
-                         "DatePublished":  "\/Date(1558058313000)\/",
+                         "DatePublished":  "\/Date(1558054713000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -136,7 +136,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-LicenseInfo",
                          "VersionAdded":  "1.0.23",
-                         "DatePublished":  "\/Date(1556956259000)\/",
+                         "DatePublished":  "\/Date(1556952659000)\/",
                          "VersionRemoved":  "",
                          "DateRemoved":  "\/Date(-62135568000000)\/",
                          "AliasedTo":  ""
@@ -148,7 +148,7 @@
                          "VersionAdded":  "1.0.69",
                          "DatePublished":  "\/Date(1576051327000)\/",
                          "VersionRemoved":  "1.1.4",
-                         "DateRemoved":  "\/Date(1622306412000)\/",
+                         "DateRemoved":  "\/Date(1622302812000)\/",
                          "AliasedTo":  null
                      },
                      {
@@ -156,9 +156,9 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Invoke-LicenseActivation",
                          "VersionAdded":  "1.1.4",
-                         "DatePublished":  "\/Date(1622306412000)\/",
+                         "DatePublished":  "\/Date(1622302812000)\/",
                          "VersionRemoved":  "25.1.39",
-                         "DateRemoved":  "\/Date(1748014837000)\/",
+                         "DateRemoved":  "\/Date(1748011237000)\/",
                          "AliasedTo":  "Invoke-VmsLicenseActivation"
                      },
                      {
@@ -166,7 +166,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Test-VmsConnection",
                          "VersionAdded":  "23.2.2",
-                         "DatePublished":  "\/Date(1695916168000)\/",
+                         "DatePublished":  "\/Date(1695912568000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -176,7 +176,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Select-Camera",
                          "VersionAdded":  "1.0.77",
-                         "DatePublished":  "\/Date(1588925223000)\/",
+                         "DatePublished":  "\/Date(1588921623000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -188,7 +188,7 @@
                          "VersionAdded":  "1.0.69",
                          "DatePublished":  "\/Date(1576051327000)\/",
                          "VersionRemoved":  "1.1.4",
-                         "DateRemoved":  "\/Date(1622306412000)\/",
+                         "DateRemoved":  "\/Date(1622302812000)\/",
                          "AliasedTo":  null
                      },
                      {
@@ -196,7 +196,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "New-VmsWebhook",
                          "VersionAdded":  "23.2.2",
-                         "DatePublished":  "\/Date(1695916168000)\/",
+                         "DatePublished":  "\/Date(1695912568000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -218,7 +218,7 @@
                          "VersionAdded":  "21.2.3",
                          "DatePublished":  "\/Date(1642755304000)\/",
                          "VersionRemoved":  "25.1.39",
-                         "DateRemoved":  "\/Date(1748014837000)\/",
+                         "DateRemoved":  "\/Date(1748011237000)\/",
                          "AliasedTo":  "Get-VmsDeviceGeneralSetting"
                      },
                      {
@@ -236,7 +236,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-PlatformItem",
                          "VersionAdded":  "1.0.46",
-                         "DatePublished":  "\/Date(1563555080000)\/",
+                         "DatePublished":  "\/Date(1563551480000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -246,7 +246,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Set-OverallSecurity",
                          "VersionAdded":  "1.0.56",
-                         "DatePublished":  "\/Date(1569633581000)\/",
+                         "DatePublished":  "\/Date(1569629981000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -256,7 +256,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Disconnect-Vms",
                          "VersionAdded":  "23.2.2",
-                         "DatePublished":  "\/Date(1695916168000)\/",
+                         "DatePublished":  "\/Date(1695912568000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -276,7 +276,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-VmsLoginProviderClaim",
                          "VersionAdded":  "23.1.1",
-                         "DatePublished":  "\/Date(1680049866000)\/",
+                         "DatePublished":  "\/Date(1680046266000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -296,7 +296,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-LicenseManager",
                          "VersionAdded":  "1.0.31",
-                         "DatePublished":  "\/Date(1558058313000)\/",
+                         "DatePublished":  "\/Date(1558054713000)\/",
                          "VersionRemoved":  "1.0.66",
                          "DateRemoved":  "\/Date(1575955525000)\/",
                          "AliasedTo":  null
@@ -316,7 +316,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-ConnectionString",
                          "VersionAdded":  "1.0.9",
-                         "DatePublished":  "\/Date(1555574744000)\/",
+                         "DatePublished":  "\/Date(1555571144000)\/",
                          "VersionRemoved":  "22.3.0",
                          "DateRemoved":  "\/Date(1669815755000)\/",
                          "AliasedTo":  "Get-VmsConnectionString"
@@ -328,7 +328,7 @@
                          "VersionAdded":  "1.0.69",
                          "DatePublished":  "\/Date(1576051327000)\/",
                          "VersionRemoved":  "1.1.4",
-                         "DateRemoved":  "\/Date(1622306412000)\/",
+                         "DateRemoved":  "\/Date(1622302812000)\/",
                          "AliasedTo":  null
                      },
                      {
@@ -336,7 +336,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Remove-VmsFailoverGroup",
                          "VersionAdded":  "21.2.2",
-                         "DatePublished":  "\/Date(1636078831000)\/",
+                         "DatePublished":  "\/Date(1636075231000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -356,7 +356,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-VmsHardwarePassword",
                          "VersionAdded":  "23.1.1",
-                         "DatePublished":  "\/Date(1680049866000)\/",
+                         "DatePublished":  "\/Date(1680046266000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -366,7 +366,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-VmsDeviceGeneralSetting",
                          "VersionAdded":  "25.1.39",
-                         "DatePublished":  "\/Date(1748014837000)\/",
+                         "DatePublished":  "\/Date(1748011237000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -376,7 +376,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-OverallSecurity",
                          "VersionAdded":  "1.0.56",
-                         "DatePublished":  "\/Date(1569633581000)\/",
+                         "DatePublished":  "\/Date(1569629981000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -386,7 +386,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Remove-VmsClientProfile",
                          "VersionAdded":  "23.1.2",
-                         "DatePublished":  "\/Date(1680940751000)\/",
+                         "DatePublished":  "\/Date(1680937151000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -396,9 +396,9 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-ProgressTest",
                          "VersionAdded":  "1.0.6",
-                         "DatePublished":  "\/Date(1555397316000)\/",
+                         "DatePublished":  "\/Date(1555393716000)\/",
                          "VersionRemoved":  "1.0.7",
-                         "DateRemoved":  "\/Date(1555483155000)\/",
+                         "DateRemoved":  "\/Date(1555479555000)\/",
                          "AliasedTo":  null
                      },
                      {
@@ -406,7 +406,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Remove-User",
                          "VersionAdded":  "1.0.6",
-                         "DatePublished":  "\/Date(1555397316000)\/",
+                         "DatePublished":  "\/Date(1555393716000)\/",
                          "VersionRemoved":  "22.3.0",
                          "DateRemoved":  "\/Date(1669815755000)\/",
                          "AliasedTo":  null
@@ -416,7 +416,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Set-VmsRestrictedMedia",
                          "VersionAdded":  "24.1.27",
-                         "DatePublished":  "\/Date(1727426172000)\/",
+                         "DatePublished":  "\/Date(1727422572000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -436,7 +436,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Save-VmsConnectionProfile",
                          "VersionAdded":  "23.2.2",
-                         "DatePublished":  "\/Date(1695916168000)\/",
+                         "DatePublished":  "\/Date(1695912568000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -446,7 +446,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Connect-ManagementServer",
                          "VersionAdded":  "1.0.6",
-                         "DatePublished":  "\/Date(1555397316000)\/",
+                         "DatePublished":  "\/Date(1555393716000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -476,7 +476,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Set-CameraSetting",
                          "VersionAdded":  "1.0.7",
-                         "DatePublished":  "\/Date(1555483155000)\/",
+                         "DatePublished":  "\/Date(1555479555000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -486,7 +486,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Remove-GenericEvent",
                          "VersionAdded":  "1.0.31",
-                         "DatePublished":  "\/Date(1558058313000)\/",
+                         "DatePublished":  "\/Date(1558054713000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -496,9 +496,9 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-Output",
                          "VersionAdded":  "1.0.10",
-                         "DatePublished":  "\/Date(1555658225000)\/",
+                         "DatePublished":  "\/Date(1555654625000)\/",
                          "VersionRemoved":  "24.1.5",
-                         "DateRemoved":  "\/Date(1719908403000)\/",
+                         "DateRemoved":  "\/Date(1719904803000)\/",
                          "AliasedTo":  "Get-VmsOutput"
                      },
                      {
@@ -516,7 +516,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-CurrentDeviceStatus",
                          "VersionAdded":  "21.1.451385",
-                         "DatePublished":  "\/Date(1625018007000)\/",
+                         "DatePublished":  "\/Date(1625014407000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -536,7 +536,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-AlarmStatistics",
                          "VersionAdded":  "1.0.81",
-                         "DatePublished":  "\/Date(1600499098000)\/",
+                         "DatePublished":  "\/Date(1600495498000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -546,7 +546,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Remove-VmsLprMatchListEntry",
                          "VersionAdded":  "24.1.6",
-                         "DatePublished":  "\/Date(1722676980000)\/",
+                         "DatePublished":  "\/Date(1722673380000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -556,7 +556,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-VmsStorage",
                          "VersionAdded":  "1.1.1",
-                         "DatePublished":  "\/Date(1621051923000)\/",
+                         "DatePublished":  "\/Date(1621048323000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -576,7 +576,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-ManagementServer",
                          "VersionAdded":  "1.0.6",
-                         "DatePublished":  "\/Date(1555397316000)\/",
+                         "DatePublished":  "\/Date(1555393716000)\/",
                          "VersionRemoved":  "21.2.6",
                          "DateRemoved":  "\/Date(1644417131000)\/",
                          "AliasedTo":  "Get-VmsManagementServer"
@@ -586,7 +586,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Remove-Stream",
                          "VersionAdded":  "1.0.7",
-                         "DatePublished":  "\/Date(1555483155000)\/",
+                         "DatePublished":  "\/Date(1555479555000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -596,7 +596,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-VmsModuleConfig",
                          "VersionAdded":  "23.3.42",
-                         "DatePublished":  "\/Date(1718091256000)\/",
+                         "DatePublished":  "\/Date(1718087656000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -606,7 +606,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-MipMessageIdList",
                          "VersionAdded":  "1.0.76",
-                         "DatePublished":  "\/Date(1586332742000)\/",
+                         "DatePublished":  "\/Date(1586329142000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -616,7 +616,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Set-HardwareSetting",
                          "VersionAdded":  "1.0.7",
-                         "DatePublished":  "\/Date(1555483155000)\/",
+                         "DatePublished":  "\/Date(1555479555000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -626,7 +626,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Set-VmsDeviceGeneralSetting",
                          "VersionAdded":  "25.1.39",
-                         "DatePublished":  "\/Date(1748014837000)\/",
+                         "DatePublished":  "\/Date(1748011237000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -636,7 +636,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Test-VmsLicensedFeature",
                          "VersionAdded":  "23.2.1",
-                         "DatePublished":  "\/Date(1692271583000)\/",
+                         "DatePublished":  "\/Date(1692267983000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -646,7 +646,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Update-AlarmLine",
                          "VersionAdded":  "1.0.81",
-                         "DatePublished":  "\/Date(1600499098000)\/",
+                         "DatePublished":  "\/Date(1600495498000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -656,7 +656,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Remove-VmsRoleClaim",
                          "VersionAdded":  "23.1.1",
-                         "DatePublished":  "\/Date(1680049866000)\/",
+                         "DatePublished":  "\/Date(1680046266000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -676,7 +676,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "ConvertFrom-ConfigurationItem",
                          "VersionAdded":  "21.1.453308",
-                         "DatePublished":  "\/Date(1631939373000)\/",
+                         "DatePublished":  "\/Date(1631935773000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -696,7 +696,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Remove-VmsConnectionProfile",
                          "VersionAdded":  "23.2.2",
-                         "DatePublished":  "\/Date(1695916168000)\/",
+                         "DatePublished":  "\/Date(1695912568000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -706,7 +706,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-PlaybackInfo",
                          "VersionAdded":  "1.0.51",
-                         "DatePublished":  "\/Date(1564306271000)\/",
+                         "DatePublished":  "\/Date(1564302671000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -726,7 +726,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-VmsRoleClaim",
                          "VersionAdded":  "23.1.1",
-                         "DatePublished":  "\/Date(1680049866000)\/",
+                         "DatePublished":  "\/Date(1680046266000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -746,7 +746,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Stop-VmsRestrictedLiveMode",
                          "VersionAdded":  "24.1.27",
-                         "DatePublished":  "\/Date(1727426172000)\/",
+                         "DatePublished":  "\/Date(1727422572000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -756,7 +756,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Set-VmsFailoverGroup",
                          "VersionAdded":  "23.2.1",
-                         "DatePublished":  "\/Date(1692271583000)\/",
+                         "DatePublished":  "\/Date(1692267983000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -766,7 +766,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Set-VmsWebhook",
                          "VersionAdded":  "23.2.2",
-                         "DatePublished":  "\/Date(1695916168000)\/",
+                         "DatePublished":  "\/Date(1695912568000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -776,7 +776,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-VmsBasicUser",
                          "VersionAdded":  "23.1.1",
-                         "DatePublished":  "\/Date(1680049866000)\/",
+                         "DatePublished":  "\/Date(1680046266000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -786,7 +786,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Set-VmsLicense",
                          "VersionAdded":  "21.2.0",
-                         "DatePublished":  "\/Date(1635400305000)\/",
+                         "DatePublished":  "\/Date(1635396705000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -798,7 +798,7 @@
                          "VersionAdded":  "1.0.66",
                          "DatePublished":  "\/Date(1575955525000)\/",
                          "VersionRemoved":  "1.1.4",
-                         "DateRemoved":  "\/Date(1622306412000)\/",
+                         "DateRemoved":  "\/Date(1622302812000)\/",
                          "AliasedTo":  null
                      },
                      {
@@ -806,7 +806,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-VmsSpeaker",
                          "VersionAdded":  "24.1.5",
-                         "DatePublished":  "\/Date(1719908403000)\/",
+                         "DatePublished":  "\/Date(1719904803000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -816,7 +816,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-Log",
                          "VersionAdded":  "1.0.9",
-                         "DatePublished":  "\/Date(1555574744000)\/",
+                         "DatePublished":  "\/Date(1555571144000)\/",
                          "VersionRemoved":  "21.2.6",
                          "DateRemoved":  "\/Date(1644417131000)\/",
                          "AliasedTo":  "Get-VmsLog"
@@ -826,7 +826,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-VmsLprMatchList",
                          "VersionAdded":  "24.1.6",
-                         "DatePublished":  "\/Date(1722676980000)\/",
+                         "DatePublished":  "\/Date(1722673380000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -836,7 +836,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-StreamProperties",
                          "VersionAdded":  "21.1.451385",
-                         "DatePublished":  "\/Date(1625018007000)\/",
+                         "DatePublished":  "\/Date(1625014407000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -846,7 +846,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-VmsLicenseDetails",
                          "VersionAdded":  "25.1.39",
-                         "DatePublished":  "\/Date(1748014837000)\/",
+                         "DatePublished":  "\/Date(1748011237000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -856,9 +856,9 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-Site",
                          "VersionAdded":  "1.0.20",
-                         "DatePublished":  "\/Date(1556687465000)\/",
+                         "DatePublished":  "\/Date(1556683865000)\/",
                          "VersionRemoved":  "23.2.1",
-                         "DateRemoved":  "\/Date(1692271583000)\/",
+                         "DateRemoved":  "\/Date(1692267983000)\/",
                          "AliasedTo":  "Get-VmsSite"
                      },
                      {
@@ -866,7 +866,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Resolve-VmsDeviceGroupPath",
                          "VersionAdded":  "21.2.0",
-                         "DatePublished":  "\/Date(1635400305000)\/",
+                         "DatePublished":  "\/Date(1635396705000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -876,7 +876,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Remove-VmsArchiveStorage",
                          "VersionAdded":  "1.1.1",
-                         "DatePublished":  "\/Date(1621051923000)\/",
+                         "DatePublished":  "\/Date(1621048323000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -886,7 +886,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Export-VmsRule",
                          "VersionAdded":  "23.1.3",
-                         "DatePublished":  "\/Date(1682064386000)\/",
+                         "DatePublished":  "\/Date(1682060786000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -896,7 +896,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-VmsInput",
                          "VersionAdded":  "24.1.5",
-                         "DatePublished":  "\/Date(1719908403000)\/",
+                         "DatePublished":  "\/Date(1719904803000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -906,7 +906,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Import-VmsRule",
                          "VersionAdded":  "23.1.3",
-                         "DatePublished":  "\/Date(1682064386000)\/",
+                         "DatePublished":  "\/Date(1682060786000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -916,7 +916,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-CameraRecordingStats",
                          "VersionAdded":  "21.1.451385",
-                         "DatePublished":  "\/Date(1625018007000)\/",
+                         "DatePublished":  "\/Date(1625014407000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -926,7 +926,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Assert-VmsRequirementsMet",
                          "VersionAdded":  "23.2.1",
-                         "DatePublished":  "\/Date(1692271583000)\/",
+                         "DatePublished":  "\/Date(1692267983000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -936,7 +936,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Select-VmsSite",
                          "VersionAdded":  "23.2.1",
-                         "DatePublished":  "\/Date(1692271583000)\/",
+                         "DatePublished":  "\/Date(1692267983000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -956,7 +956,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-VmsVideoOSItem",
                          "VersionAdded":  "23.2.1",
-                         "DatePublished":  "\/Date(1692271583000)\/",
+                         "DatePublished":  "\/Date(1692267983000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -966,7 +966,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Set-VmsLoginProviderClaim",
                          "VersionAdded":  "23.1.1",
-                         "DatePublished":  "\/Date(1680049866000)\/",
+                         "DatePublished":  "\/Date(1680046266000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -976,7 +976,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Select-VideoOSItem",
                          "VersionAdded":  "1.0.77",
-                         "DatePublished":  "\/Date(1588925223000)\/",
+                         "DatePublished":  "\/Date(1588921623000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -986,7 +986,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-VmsMetadataRecord",
                          "VersionAdded":  "23.3.51",
-                         "DatePublished":  "\/Date(1719046079000)\/",
+                         "DatePublished":  "\/Date(1719042479000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -996,7 +996,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "New-VmsBasicUser",
                          "VersionAdded":  "23.1.1",
-                         "DatePublished":  "\/Date(1680049866000)\/",
+                         "DatePublished":  "\/Date(1680046266000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -1006,7 +1006,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Import-VmsHardware",
                          "VersionAdded":  "21.2.0",
-                         "DatePublished":  "\/Date(1635400305000)\/",
+                         "DatePublished":  "\/Date(1635396705000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -1016,7 +1016,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-VideoDeviceStatistics",
                          "VersionAdded":  "21.1.451385",
-                         "DatePublished":  "\/Date(1625018007000)\/",
+                         "DatePublished":  "\/Date(1625014407000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -1026,7 +1026,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Add-VmsFailoverRecorder",
                          "VersionAdded":  "23.2.1",
-                         "DatePublished":  "\/Date(1692271583000)\/",
+                         "DatePublished":  "\/Date(1692267983000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -1036,7 +1036,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Set-VmsSiteInfo",
                          "VersionAdded":  "22.1.0",
-                         "DatePublished":  "\/Date(1650435259000)\/",
+                         "DatePublished":  "\/Date(1650431659000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -1046,7 +1046,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Split-VmsConfigItemPath",
                          "VersionAdded":  "23.2.3",
-                         "DatePublished":  "\/Date(1697049784000)\/",
+                         "DatePublished":  "\/Date(1697046184000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -1056,7 +1056,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-EvidenceLock",
                          "VersionAdded":  "1.0.12",
-                         "DatePublished":  "\/Date(1556086129000)\/",
+                         "DatePublished":  "\/Date(1556082529000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -1066,7 +1066,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-VmsSiteInfo",
                          "VersionAdded":  "22.1.0",
-                         "DatePublished":  "\/Date(1650435259000)\/",
+                         "DatePublished":  "\/Date(1650431659000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -1076,7 +1076,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Start-VmsRestrictedLiveMode",
                          "VersionAdded":  "24.1.27",
-                         "DatePublished":  "\/Date(1727426172000)\/",
+                         "DatePublished":  "\/Date(1727422572000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -1086,7 +1086,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-IServerCommandService",
                          "VersionAdded":  "1.0.31",
-                         "DatePublished":  "\/Date(1558058313000)\/",
+                         "DatePublished":  "\/Date(1558054713000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -1096,7 +1096,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Remove-VmsHardware",
                          "VersionAdded":  "23.2.2",
-                         "DatePublished":  "\/Date(1695916168000)\/",
+                         "DatePublished":  "\/Date(1695912568000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -1106,7 +1106,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-GenericEventDataSource",
                          "VersionAdded":  "1.0.30",
-                         "DatePublished":  "\/Date(1557818250000)\/",
+                         "DatePublished":  "\/Date(1557814650000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -1116,9 +1116,9 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Invoke-MipSdkEula",
                          "VersionAdded":  "1.0.64",
-                         "DatePublished":  "\/Date(1572668509000)\/",
+                         "DatePublished":  "\/Date(1572664909000)\/",
                          "VersionRemoved":  "25.2.1",
-                         "DateRemoved":  "\/Date(1749626935000)\/",
+                         "DateRemoved":  "\/Date(1749623335000)\/",
                          "AliasedTo":  null
                      },
                      {
@@ -1126,7 +1126,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Add-VmsLoginProviderClaim",
                          "VersionAdded":  "23.1.1",
-                         "DatePublished":  "\/Date(1680049866000)\/",
+                         "DatePublished":  "\/Date(1680046266000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -1146,7 +1146,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-VmsDeviceStreamSetting",
                          "VersionAdded":  "25.1.39",
-                         "DatePublished":  "\/Date(1748014837000)\/",
+                         "DatePublished":  "\/Date(1748011237000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -1156,7 +1156,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "New-VmsRestrictedMedia",
                          "VersionAdded":  "24.1.27",
-                         "DatePublished":  "\/Date(1727426172000)\/",
+                         "DatePublished":  "\/Date(1727422572000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -1186,7 +1186,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-VmsFailoverGroup",
                          "VersionAdded":  "21.2.2",
-                         "DatePublished":  "\/Date(1636078831000)\/",
+                         "DatePublished":  "\/Date(1636075231000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -1196,7 +1196,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Set-VmsHardware",
                          "VersionAdded":  "23.1.1",
-                         "DatePublished":  "\/Date(1680049866000)\/",
+                         "DatePublished":  "\/Date(1680046266000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -1216,7 +1216,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Update-Bookmark",
                          "VersionAdded":  "1.0.12",
-                         "DatePublished":  "\/Date(1556086129000)\/",
+                         "DatePublished":  "\/Date(1556082529000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -1226,7 +1226,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Copy-VmsClientProfile",
                          "VersionAdded":  "23.1.2",
-                         "DatePublished":  "\/Date(1680940751000)\/",
+                         "DatePublished":  "\/Date(1680937151000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -1236,7 +1236,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-VmsLicensedProducts",
                          "VersionAdded":  "25.1.39",
-                         "DatePublished":  "\/Date(1748014837000)\/",
+                         "DatePublished":  "\/Date(1748011237000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -1246,7 +1246,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Set-VmsLprMatchList",
                          "VersionAdded":  "24.1.6",
-                         "DatePublished":  "\/Date(1722676980000)\/",
+                         "DatePublished":  "\/Date(1722673380000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -1256,7 +1256,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "ConvertFrom-ConfigurationApiProperties",
                          "VersionAdded":  "21.2.0",
-                         "DatePublished":  "\/Date(1635400305000)\/",
+                         "DatePublished":  "\/Date(1635396705000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -1266,9 +1266,9 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-LicensedProducts",
                          "VersionAdded":  "1.1.4",
-                         "DatePublished":  "\/Date(1622306412000)\/",
+                         "DatePublished":  "\/Date(1622302812000)\/",
                          "VersionRemoved":  "25.1.39",
-                         "DateRemoved":  "\/Date(1748014837000)\/",
+                         "DateRemoved":  "\/Date(1748011237000)\/",
                          "AliasedTo":  "Get-VmsLicensedProducts"
                      },
                      {
@@ -1276,7 +1276,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Set-Stream",
                          "VersionAdded":  "1.0.7",
-                         "DatePublished":  "\/Date(1555483155000)\/",
+                         "DatePublished":  "\/Date(1555479555000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -1288,7 +1288,7 @@
                          "VersionAdded":  "1.0.69",
                          "DatePublished":  "\/Date(1576051327000)\/",
                          "VersionRemoved":  "1.1.4",
-                         "DateRemoved":  "\/Date(1622306412000)\/",
+                         "DateRemoved":  "\/Date(1622302812000)\/",
                          "AliasedTo":  null
                      },
                      {
@@ -1296,7 +1296,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Set-VmsSpeaker",
                          "VersionAdded":  "24.1.5",
-                         "DatePublished":  "\/Date(1719908403000)\/",
+                         "DatePublished":  "\/Date(1719904803000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -1306,7 +1306,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Add-VmsLprMatchListEntry",
                          "VersionAdded":  "24.1.6",
-                         "DatePublished":  "\/Date(1722676980000)\/",
+                         "DatePublished":  "\/Date(1722673380000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -1316,7 +1316,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Find-VmsVideoOSItem",
                          "VersionAdded":  "23.2.1",
-                         "DatePublished":  "\/Date(1692271583000)\/",
+                         "DatePublished":  "\/Date(1692267983000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -1336,7 +1336,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Export-VmsRole",
                          "VersionAdded":  "23.1.2",
-                         "DatePublished":  "\/Date(1680940751000)\/",
+                         "DatePublished":  "\/Date(1680937151000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -1346,7 +1346,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-UserDefinedEvent",
                          "VersionAdded":  "1.0.10",
-                         "DatePublished":  "\/Date(1555658225000)\/",
+                         "DatePublished":  "\/Date(1555654625000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -1356,7 +1356,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Add-DeviceGroup",
                          "VersionAdded":  "1.0.6",
-                         "DatePublished":  "\/Date(1555397316000)\/",
+                         "DatePublished":  "\/Date(1555393716000)\/",
                          "VersionRemoved":  "22.3.0",
                          "DateRemoved":  "\/Date(1669815755000)\/",
                          "AliasedTo":  "New-VmsDeviceGroup"
@@ -1366,7 +1366,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Set-VmsDeviceStorage",
                          "VersionAdded":  "23.3.33",
-                         "DatePublished":  "\/Date(1718084557000)\/",
+                         "DatePublished":  "\/Date(1718080957000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -1376,7 +1376,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-VmsSystemLicense",
                          "VersionAdded":  "23.2.1",
-                         "DatePublished":  "\/Date(1692271583000)\/",
+                         "DatePublished":  "\/Date(1692267983000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -1386,9 +1386,9 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Remove-Hardware",
                          "VersionAdded":  "1.0.6",
-                         "DatePublished":  "\/Date(1555397316000)\/",
+                         "DatePublished":  "\/Date(1555393716000)\/",
                          "VersionRemoved":  "23.2.2",
-                         "DateRemoved":  "\/Date(1695916168000)\/",
+                         "DateRemoved":  "\/Date(1695912568000)\/",
                          "AliasedTo":  "Remove-VmsHardware"
                      },
                      {
@@ -1396,7 +1396,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Update-RegisteredService",
                          "VersionAdded":  "1.0.12",
-                         "DatePublished":  "\/Date(1556086129000)\/",
+                         "DatePublished":  "\/Date(1556082529000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -1406,9 +1406,9 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-ValueDisplayName",
                          "VersionAdded":  "21.1.451385",
-                         "DatePublished":  "\/Date(1625018007000)\/",
+                         "DatePublished":  "\/Date(1625014407000)\/",
                          "VersionRemoved":  "25.1.39",
-                         "DateRemoved":  "\/Date(1748014837000)\/",
+                         "DateRemoved":  "\/Date(1748011237000)\/",
                          "AliasedTo":  null
                      },
                      {
@@ -1416,7 +1416,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Add-Hardware",
                          "VersionAdded":  "1.0.6",
-                         "DatePublished":  "\/Date(1555397316000)\/",
+                         "DatePublished":  "\/Date(1555393716000)\/",
                          "VersionRemoved":  "22.3.0",
                          "DateRemoved":  "\/Date(1669815755000)\/",
                          "AliasedTo":  null
@@ -1426,7 +1426,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-RegisteredService",
                          "VersionAdded":  "1.0.12",
-                         "DatePublished":  "\/Date(1556086129000)\/",
+                         "DatePublished":  "\/Date(1556082529000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -1436,7 +1436,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-VmsDevice",
                          "VersionAdded":  "24.1.6",
-                         "DatePublished":  "\/Date(1722676980000)\/",
+                         "DatePublished":  "\/Date(1722673380000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -1446,7 +1446,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Add-Role",
                          "VersionAdded":  "1.0.6",
-                         "DatePublished":  "\/Date(1555397316000)\/",
+                         "DatePublished":  "\/Date(1555393716000)\/",
                          "VersionRemoved":  "22.3.0",
                          "DateRemoved":  "\/Date(1669815755000)\/",
                          "AliasedTo":  "New-VmsRole"
@@ -1456,7 +1456,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "ConvertFrom-Snapshot",
                          "VersionAdded":  "21.1.451385",
-                         "DatePublished":  "\/Date(1625018007000)\/",
+                         "DatePublished":  "\/Date(1625014407000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -1466,7 +1466,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Invoke-VmsLicenseActivation",
                          "VersionAdded":  "21.2.0",
-                         "DatePublished":  "\/Date(1635400305000)\/",
+                         "DatePublished":  "\/Date(1635396705000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -1476,7 +1476,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Import-HardwareCsv",
                          "VersionAdded":  "1.0.56",
-                         "DatePublished":  "\/Date(1569633581000)\/",
+                         "DatePublished":  "\/Date(1569629981000)\/",
                          "VersionRemoved":  "22.3.0",
                          "DateRemoved":  "\/Date(1669815755000)\/",
                          "AliasedTo":  null
@@ -1486,7 +1486,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Add-UserDefinedEvent",
                          "VersionAdded":  "1.0.10",
-                         "DatePublished":  "\/Date(1555658225000)\/",
+                         "DatePublished":  "\/Date(1555654625000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -1496,7 +1496,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Remove-VmsLoginProvider",
                          "VersionAdded":  "23.1.1",
-                         "DatePublished":  "\/Date(1680049866000)\/",
+                         "DatePublished":  "\/Date(1680046266000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -1506,7 +1506,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Export-VmsClientProfile",
                          "VersionAdded":  "23.1.2",
-                         "DatePublished":  "\/Date(1680940751000)\/",
+                         "DatePublished":  "\/Date(1680937151000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -1516,7 +1516,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-Camera",
                          "VersionAdded":  "1.0.8",
-                         "DatePublished":  "\/Date(1555501851000)\/",
+                         "DatePublished":  "\/Date(1555498251000)\/",
                          "VersionRemoved":  "21.2.7",
                          "DateRemoved":  "\/Date(1645681660000)\/",
                          "AliasedTo":  "Get-VmsCamera"
@@ -1526,7 +1526,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Clear-VmsLprMatchList",
                          "VersionAdded":  "24.1.6",
-                         "DatePublished":  "\/Date(1722676980000)\/",
+                         "DatePublished":  "\/Date(1722673380000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -1546,7 +1546,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Remove-VmsLprMatchList",
                          "VersionAdded":  "24.1.6",
-                         "DatePublished":  "\/Date(1722676980000)\/",
+                         "DatePublished":  "\/Date(1722673380000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -1566,9 +1566,9 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Set-HardwarePassword",
                          "VersionAdded":  "1.0.9",
-                         "DatePublished":  "\/Date(1555574744000)\/",
+                         "DatePublished":  "\/Date(1555571144000)\/",
                          "VersionRemoved":  "23.1.1",
-                         "DateRemoved":  "\/Date(1680049866000)\/",
+                         "DateRemoved":  "\/Date(1680046266000)\/",
                          "AliasedTo":  "Set-VmsHardware"
                      },
                      {
@@ -1576,9 +1576,9 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-Microphone",
                          "VersionAdded":  "1.0.10",
-                         "DatePublished":  "\/Date(1555658225000)\/",
+                         "DatePublished":  "\/Date(1555654625000)\/",
                          "VersionRemoved":  "24.1.5",
-                         "DateRemoved":  "\/Date(1719908403000)\/",
+                         "DateRemoved":  "\/Date(1719904803000)\/",
                          "AliasedTo":  "Get-VmsMicrophone"
                      },
                      {
@@ -1596,7 +1596,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Assert-VmsLicensedFeature",
                          "VersionAdded":  "23.2.1",
-                         "DatePublished":  "\/Date(1692271583000)\/",
+                         "DatePublished":  "\/Date(1692267983000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -1616,9 +1616,9 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Set-RecorderConfig",
                          "VersionAdded":  "1.0.57",
-                         "DatePublished":  "\/Date(1569987384000)\/",
+                         "DatePublished":  "\/Date(1569983784000)\/",
                          "VersionRemoved":  "1.1.5",
-                         "DateRemoved":  "\/Date(1622709061000)\/",
+                         "DateRemoved":  "\/Date(1622705461000)\/",
                          "AliasedTo":  null
                      },
                      {
@@ -1656,7 +1656,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-HardwareDriver",
                          "VersionAdded":  "1.0.6",
-                         "DatePublished":  "\/Date(1555397316000)\/",
+                         "DatePublished":  "\/Date(1555393716000)\/",
                          "VersionRemoved":  "22.3.1",
                          "DateRemoved":  "\/Date(1676015674000)\/",
                          "AliasedTo":  "Get-VmsHardwareDriver"
@@ -1666,7 +1666,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Set-VmsInput",
                          "VersionAdded":  "24.1.5",
-                         "DatePublished":  "\/Date(1719908403000)\/",
+                         "DatePublished":  "\/Date(1719904803000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -1676,7 +1676,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-VmsLprMatchListEntry",
                          "VersionAdded":  "24.1.6",
-                         "DatePublished":  "\/Date(1722676980000)\/",
+                         "DatePublished":  "\/Date(1722673380000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -1686,7 +1686,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-Hardware",
                          "VersionAdded":  "1.0.6",
-                         "DatePublished":  "\/Date(1555397316000)\/",
+                         "DatePublished":  "\/Date(1555393716000)\/",
                          "VersionRemoved":  "22.3.0",
                          "DateRemoved":  "\/Date(1669815755000)\/",
                          "AliasedTo":  "Get-VmsHardware"
@@ -1696,7 +1696,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-DeviceAcl",
                          "VersionAdded":  "1.0.6",
-                         "DatePublished":  "\/Date(1555397316000)\/",
+                         "DatePublished":  "\/Date(1555393716000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -1706,7 +1706,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-IConfigurationService",
                          "VersionAdded":  "1.0.31",
-                         "DatePublished":  "\/Date(1558058313000)\/",
+                         "DatePublished":  "\/Date(1558054713000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -1718,7 +1718,7 @@
                          "VersionAdded":  "1.0.69",
                          "DatePublished":  "\/Date(1576051327000)\/",
                          "VersionRemoved":  "1.1.4",
-                         "DateRemoved":  "\/Date(1622306412000)\/",
+                         "DateRemoved":  "\/Date(1622302812000)\/",
                          "AliasedTo":  null
                      },
                      {
@@ -1726,7 +1726,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Export-VmsHardware",
                          "VersionAdded":  "21.2.0",
-                         "DatePublished":  "\/Date(1635400305000)\/",
+                         "DatePublished":  "\/Date(1635396705000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -1736,7 +1736,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-VmsLicenseOverview",
                          "VersionAdded":  "25.1.39",
-                         "DatePublished":  "\/Date(1748014837000)\/",
+                         "DatePublished":  "\/Date(1748011237000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -1746,7 +1746,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-InputSetting",
                          "VersionAdded":  "1.0.10",
-                         "DatePublished":  "\/Date(1555658225000)\/",
+                         "DatePublished":  "\/Date(1555654625000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -1766,7 +1766,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-VmsWebhook",
                          "VersionAdded":  "23.2.2",
-                         "DatePublished":  "\/Date(1695916168000)\/",
+                         "DatePublished":  "\/Date(1695912568000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -1776,7 +1776,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-AlarmLine",
                          "VersionAdded":  "1.0.81",
-                         "DatePublished":  "\/Date(1600499098000)\/",
+                         "DatePublished":  "\/Date(1600495498000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -1786,7 +1786,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-VmsClientProfile",
                          "VersionAdded":  "23.1.2",
-                         "DatePublished":  "\/Date(1680940751000)\/",
+                         "DatePublished":  "\/Date(1680937151000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -1796,7 +1796,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Import-VmsLicense",
                          "VersionAdded":  "21.2.0",
-                         "DatePublished":  "\/Date(1635400305000)\/",
+                         "DatePublished":  "\/Date(1635396705000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -1806,7 +1806,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-Role",
                          "VersionAdded":  "1.0.6",
-                         "DatePublished":  "\/Date(1555397316000)\/",
+                         "DatePublished":  "\/Date(1555393716000)\/",
                          "VersionRemoved":  "22.3.0",
                          "DateRemoved":  "\/Date(1669815755000)\/",
                          "AliasedTo":  null
@@ -1816,7 +1816,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Trace-Events",
                          "VersionAdded":  "1.0.23",
-                         "DatePublished":  "\/Date(1556956259000)\/",
+                         "DatePublished":  "\/Date(1556952659000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -1826,7 +1826,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Set-VmsMetadata",
                          "VersionAdded":  "24.1.5",
-                         "DatePublished":  "\/Date(1719908403000)\/",
+                         "DatePublished":  "\/Date(1719904803000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -1836,7 +1836,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Add-DeviceGroupMember",
                          "VersionAdded":  "1.0.12",
-                         "DatePublished":  "\/Date(1556086129000)\/",
+                         "DatePublished":  "\/Date(1556082529000)\/",
                          "VersionRemoved":  "22.3.0",
                          "DateRemoved":  "\/Date(1669815755000)\/",
                          "AliasedTo":  "Add-VmsDeviceGroupMember"
@@ -1846,7 +1846,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Add-VmsStorage",
                          "VersionAdded":  "1.1.1",
-                         "DatePublished":  "\/Date(1621051923000)\/",
+                         "DatePublished":  "\/Date(1621048323000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -1856,7 +1856,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Set-VmsLoginProvider",
                          "VersionAdded":  "23.1.1",
-                         "DatePublished":  "\/Date(1680049866000)\/",
+                         "DatePublished":  "\/Date(1680046266000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -1866,7 +1866,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-MicrophoneSetting",
                          "VersionAdded":  "1.0.10",
-                         "DatePublished":  "\/Date(1555658225000)\/",
+                         "DatePublished":  "\/Date(1555654625000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -1876,7 +1876,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-User",
                          "VersionAdded":  "1.0.6",
-                         "DatePublished":  "\/Date(1555397316000)\/",
+                         "DatePublished":  "\/Date(1555393716000)\/",
                          "VersionRemoved":  "22.3.0",
                          "DateRemoved":  "\/Date(1669815755000)\/",
                          "AliasedTo":  null
@@ -1896,7 +1896,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-DeviceGroup",
                          "VersionAdded":  "1.0.6",
-                         "DatePublished":  "\/Date(1555397316000)\/",
+                         "DatePublished":  "\/Date(1555393716000)\/",
                          "VersionRemoved":  "22.3.0",
                          "DateRemoved":  "\/Date(1669815755000)\/",
                          "AliasedTo":  "Get-VmsDeviceGroup"
@@ -1916,7 +1916,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-VmsClientProfileAttributes",
                          "VersionAdded":  "23.1.2",
-                         "DatePublished":  "\/Date(1680940751000)\/",
+                         "DatePublished":  "\/Date(1680937151000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -1936,7 +1936,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Add-VmsRoleClaim",
                          "VersionAdded":  "23.1.1",
-                         "DatePublished":  "\/Date(1680049866000)\/",
+                         "DatePublished":  "\/Date(1680046266000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -1946,9 +1946,9 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-Speaker",
                          "VersionAdded":  "1.0.10",
-                         "DatePublished":  "\/Date(1555658225000)\/",
+                         "DatePublished":  "\/Date(1555654625000)\/",
                          "VersionRemoved":  "24.1.5",
-                         "DateRemoved":  "\/Date(1719908403000)\/",
+                         "DateRemoved":  "\/Date(1719904803000)\/",
                          "AliasedTo":  "Get-VmsSpeaker"
                      },
                      {
@@ -1956,7 +1956,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Set-VmsDeviceEvent",
                          "VersionAdded":  "23.2.3",
-                         "DatePublished":  "\/Date(1697049784000)\/",
+                         "DatePublished":  "\/Date(1697046184000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -1966,7 +1966,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Set-MicrophoneSetting",
                          "VersionAdded":  "1.0.10",
-                         "DatePublished":  "\/Date(1555658225000)\/",
+                         "DatePublished":  "\/Date(1555654625000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -1976,7 +1976,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-ManagementServerConfig",
                          "VersionAdded":  "1.0.80",
-                         "DatePublished":  "\/Date(1600310905000)\/",
+                         "DatePublished":  "\/Date(1600307305000)\/",
                          "VersionRemoved":  "",
                          "DateRemoved":  "\/Date(-62135568000000)\/",
                          "AliasedTo":  ""
@@ -1986,7 +1986,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Set-VmsRule",
                          "VersionAdded":  "23.1.3",
-                         "DatePublished":  "\/Date(1682064386000)\/",
+                         "DatePublished":  "\/Date(1682060786000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -1996,7 +1996,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Set-VmsModuleConfig",
                          "VersionAdded":  "23.3.42",
-                         "DatePublished":  "\/Date(1718091256000)\/",
+                         "DatePublished":  "\/Date(1718087656000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -2006,7 +2006,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Move-VmsHardware",
                          "VersionAdded":  "23.2.3",
-                         "DatePublished":  "\/Date(1697049784000)\/",
+                         "DatePublished":  "\/Date(1697046184000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -2026,7 +2026,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-EventLine",
                          "VersionAdded":  "1.0.81",
-                         "DatePublished":  "\/Date(1600499098000)\/",
+                         "DatePublished":  "\/Date(1600495498000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -2036,7 +2036,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Send-GenericEvent",
                          "VersionAdded":  "1.0.49",
-                         "DatePublished":  "\/Date(1564247988000)\/",
+                         "DatePublished":  "\/Date(1564244388000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -2056,7 +2056,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Clear-VmsSiteInfo",
                          "VersionAdded":  "22.1.0",
-                         "DatePublished":  "\/Date(1650435259000)\/",
+                         "DatePublished":  "\/Date(1650431659000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -2066,7 +2066,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Set-VmsBasicUser",
                          "VersionAdded":  "23.1.1",
-                         "DatePublished":  "\/Date(1680049866000)\/",
+                         "DatePublished":  "\/Date(1680046266000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -2076,7 +2076,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-VmsMetadataLiveRecord",
                          "VersionAdded":  "23.3.51",
-                         "DatePublished":  "\/Date(1719046079000)\/",
+                         "DatePublished":  "\/Date(1719042479000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -2086,7 +2086,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Set-MobileServerCertificate",
                          "VersionAdded":  "1.0.56",
-                         "DatePublished":  "\/Date(1569633581000)\/",
+                         "DatePublished":  "\/Date(1569629981000)\/",
                          "VersionRemoved":  "22.3.0",
                          "DateRemoved":  "\/Date(1669815755000)\/",
                          "AliasedTo":  null
@@ -2096,7 +2096,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Add-VmsArchiveStorage",
                          "VersionAdded":  "1.1.1",
-                         "DatePublished":  "\/Date(1621051923000)\/",
+                         "DatePublished":  "\/Date(1621048323000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -2116,7 +2116,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Update-EvidenceLock",
                          "VersionAdded":  "1.0.12",
-                         "DatePublished":  "\/Date(1556086129000)\/",
+                         "DatePublished":  "\/Date(1556082529000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -2136,7 +2136,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Add-Bookmark",
                          "VersionAdded":  "1.0.12",
-                         "DatePublished":  "\/Date(1556086129000)\/",
+                         "DatePublished":  "\/Date(1556082529000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -2146,7 +2146,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Remove-EvidenceLock",
                          "VersionAdded":  "1.0.12",
-                         "DatePublished":  "\/Date(1556086129000)\/",
+                         "DatePublished":  "\/Date(1556082529000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -2156,7 +2156,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Connect-Vms",
                          "VersionAdded":  "23.2.2",
-                         "DatePublished":  "\/Date(1695916168000)\/",
+                         "DatePublished":  "\/Date(1695912568000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -2166,7 +2166,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Copy-EvidenceLock",
                          "VersionAdded":  "1.0.36",
-                         "DatePublished":  "\/Date(1559807618000)\/",
+                         "DatePublished":  "\/Date(1559804018000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -2176,7 +2176,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Start-VmsHardwareScan",
                          "VersionAdded":  "21.2.0",
-                         "DatePublished":  "\/Date(1635400305000)\/",
+                         "DatePublished":  "\/Date(1635396705000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -2186,7 +2186,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Set-VmsCameraMotion",
                          "VersionAdded":  "23.3.33",
-                         "DatePublished":  "\/Date(1718084557000)\/",
+                         "DatePublished":  "\/Date(1718080957000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -2196,7 +2196,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Remove-MobileServerCertificate",
                          "VersionAdded":  "1.0.56",
-                         "DatePublished":  "\/Date(1569633581000)\/",
+                         "DatePublished":  "\/Date(1569629981000)\/",
                          "VersionRemoved":  "22.3.0",
                          "DateRemoved":  "\/Date(1669815755000)\/",
                          "AliasedTo":  null
@@ -2206,7 +2206,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-Diagnostics",
                          "VersionAdded":  "1.0.23",
-                         "DatePublished":  "\/Date(1556956259000)\/",
+                         "DatePublished":  "\/Date(1556952659000)\/",
                          "VersionRemoved":  "1.0.87",
                          "DateRemoved":  "\/Date(1607395261000)\/",
                          "AliasedTo":  null
@@ -2218,7 +2218,7 @@
                          "VersionAdded":  "1.0.69",
                          "DatePublished":  "\/Date(1576051327000)\/",
                          "VersionRemoved":  "1.1.4",
-                         "DateRemoved":  "\/Date(1622306412000)\/",
+                         "DateRemoved":  "\/Date(1622302812000)\/",
                          "AliasedTo":  null
                      },
                      {
@@ -2226,7 +2226,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Send-UserDefinedEvent",
                          "VersionAdded":  "1.0.10",
-                         "DatePublished":  "\/Date(1555658225000)\/",
+                         "DatePublished":  "\/Date(1555654625000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -2236,7 +2236,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Import-VmsLprMatchList",
                          "VersionAdded":  "24.1.6",
-                         "DatePublished":  "\/Date(1722676980000)\/",
+                         "DatePublished":  "\/Date(1722673380000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -2246,7 +2246,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "New-AlarmOrder",
                          "VersionAdded":  "1.0.81",
-                         "DatePublished":  "\/Date(1600499098000)\/",
+                         "DatePublished":  "\/Date(1600495498000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -2256,7 +2256,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Remove-Role",
                          "VersionAdded":  "1.0.6",
-                         "DatePublished":  "\/Date(1555397316000)\/",
+                         "DatePublished":  "\/Date(1555393716000)\/",
                          "VersionRemoved":  "22.3.0",
                          "DateRemoved":  "\/Date(1669815755000)\/",
                          "AliasedTo":  "Remove-VmsRole"
@@ -2266,7 +2266,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-SequenceData",
                          "VersionAdded":  "1.0.40",
-                         "DatePublished":  "\/Date(1560319477000)\/",
+                         "DatePublished":  "\/Date(1560315877000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -2276,7 +2276,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Set-VmsClientProfileAttributes",
                          "VersionAdded":  "23.1.2",
-                         "DatePublished":  "\/Date(1680940751000)\/",
+                         "DatePublished":  "\/Date(1680937151000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -2286,9 +2286,9 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Add-VmsFailoverGroup",
                          "VersionAdded":  "21.2.2",
-                         "DatePublished":  "\/Date(1636078831000)\/",
+                         "DatePublished":  "\/Date(1636075231000)\/",
                          "VersionRemoved":  "23.2.1",
-                         "DateRemoved":  "\/Date(1692271583000)\/",
+                         "DateRemoved":  "\/Date(1692267983000)\/",
                          "AliasedTo":  null
                      },
                      {
@@ -2306,7 +2306,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-VmsLoginProvider",
                          "VersionAdded":  "23.1.1",
-                         "DatePublished":  "\/Date(1680049866000)\/",
+                         "DatePublished":  "\/Date(1680046266000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -2316,7 +2316,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Remove-VmsStorage",
                          "VersionAdded":  "1.1.1",
-                         "DatePublished":  "\/Date(1621051923000)\/",
+                         "DatePublished":  "\/Date(1621048323000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -2326,7 +2326,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Send-MipMessage",
                          "VersionAdded":  "1.0.76",
-                         "DatePublished":  "\/Date(1586332742000)\/",
+                         "DatePublished":  "\/Date(1586329142000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -2336,7 +2336,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Remove-VmsRule",
                          "VersionAdded":  "23.1.3",
-                         "DatePublished":  "\/Date(1682064386000)\/",
+                         "DatePublished":  "\/Date(1682060786000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -2346,7 +2346,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Remove-VmsLoginProviderClaim",
                          "VersionAdded":  "23.1.1",
-                         "DatePublished":  "\/Date(1680049866000)\/",
+                         "DatePublished":  "\/Date(1680046266000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -2356,9 +2356,9 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-Metadata",
                          "VersionAdded":  "1.0.10",
-                         "DatePublished":  "\/Date(1555658225000)\/",
+                         "DatePublished":  "\/Date(1555654625000)\/",
                          "VersionRemoved":  "24.1.5",
-                         "DateRemoved":  "\/Date(1719908403000)\/",
+                         "DateRemoved":  "\/Date(1719904803000)\/",
                          "AliasedTo":  null
                      },
                      {
@@ -2366,7 +2366,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Set-VmsFailoverRecorder",
                          "VersionAdded":  "23.2.1",
-                         "DatePublished":  "\/Date(1692271583000)\/",
+                         "DatePublished":  "\/Date(1692267983000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -2376,7 +2376,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-RecordingServer",
                          "VersionAdded":  "1.0.6",
-                         "DatePublished":  "\/Date(1555397316000)\/",
+                         "DatePublished":  "\/Date(1555393716000)\/",
                          "VersionRemoved":  "22.3.0",
                          "DateRemoved":  "\/Date(1669815755000)\/",
                          "AliasedTo":  "Get-VmsRecordingServer"
@@ -2386,7 +2386,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-SpeakerSetting",
                          "VersionAdded":  "1.0.10",
-                         "DatePublished":  "\/Date(1555658225000)\/",
+                         "DatePublished":  "\/Date(1555654625000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -2406,7 +2406,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Set-VmsDeviceStreamSetting",
                          "VersionAdded":  "25.1.39",
-                         "DatePublished":  "\/Date(1748014837000)\/",
+                         "DatePublished":  "\/Date(1748011237000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -2426,7 +2426,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Copy-VmsRole",
                          "VersionAdded":  "23.1.2",
-                         "DatePublished":  "\/Date(1680940751000)\/",
+                         "DatePublished":  "\/Date(1680937151000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -2436,7 +2436,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-ItemState",
                          "VersionAdded":  "1.0.45",
-                         "DatePublished":  "\/Date(1563523725000)\/",
+                         "DatePublished":  "\/Date(1563520125000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -2446,9 +2446,9 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-MipSdkEula",
                          "VersionAdded":  "1.0.64",
-                         "DatePublished":  "\/Date(1572668509000)\/",
+                         "DatePublished":  "\/Date(1572664909000)\/",
                          "VersionRemoved":  "25.2.1",
-                         "DateRemoved":  "\/Date(1749626935000)\/",
+                         "DateRemoved":  "\/Date(1749623335000)\/",
                          "AliasedTo":  null
                      },
                      {
@@ -2456,7 +2456,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Set-VmsMicrophone",
                          "VersionAdded":  "24.1.5",
-                         "DatePublished":  "\/Date(1719908403000)\/",
+                         "DatePublished":  "\/Date(1719904803000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -2476,7 +2476,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-VmsCameraReport",
                          "VersionAdded":  "21.2.0",
-                         "DatePublished":  "\/Date(1635400305000)\/",
+                         "DatePublished":  "\/Date(1635396705000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -2486,9 +2486,9 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Initialize-RecordingServer",
                          "VersionAdded":  "1.0.39",
-                         "DatePublished":  "\/Date(1560224947000)\/",
+                         "DatePublished":  "\/Date(1560221347000)\/",
                          "VersionRemoved":  "1.0.78",
-                         "DateRemoved":  "\/Date(1592367506000)\/",
+                         "DateRemoved":  "\/Date(1592363906000)\/",
                          "AliasedTo":  null
                      },
                      {
@@ -2496,7 +2496,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-VideoSource",
                          "VersionAdded":  "1.0.53",
-                         "DatePublished":  "\/Date(1565751404000)\/",
+                         "DatePublished":  "\/Date(1565747804000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -2506,7 +2506,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-Token",
                          "VersionAdded":  "1.0.20",
-                         "DatePublished":  "\/Date(1556687465000)\/",
+                         "DatePublished":  "\/Date(1556683865000)\/",
                          "VersionRemoved":  "22.3.0",
                          "DateRemoved":  "\/Date(1669815755000)\/",
                          "AliasedTo":  "Get-VmsToken"
@@ -2526,7 +2526,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Remove-DeviceGroup",
                          "VersionAdded":  "1.0.6",
-                         "DatePublished":  "\/Date(1555397316000)\/",
+                         "DatePublished":  "\/Date(1555393716000)\/",
                          "VersionRemoved":  "22.3.0",
                          "DateRemoved":  "\/Date(1669815755000)\/",
                          "AliasedTo":  "Remove-VmsDeviceGroup"
@@ -2536,7 +2536,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "New-VmsClientProfile",
                          "VersionAdded":  "23.1.2",
-                         "DatePublished":  "\/Date(1680940751000)\/",
+                         "DatePublished":  "\/Date(1680937151000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -2546,7 +2546,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Disconnect-ManagementServer",
                          "VersionAdded":  "1.0.6",
-                         "DatePublished":  "\/Date(1555397316000)\/",
+                         "DatePublished":  "\/Date(1555393716000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -2556,7 +2556,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Set-SpeakerSetting",
                          "VersionAdded":  "1.0.10",
-                         "DatePublished":  "\/Date(1555658225000)\/",
+                         "DatePublished":  "\/Date(1555654625000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -2566,7 +2566,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-VmsSite",
                          "VersionAdded":  "23.2.1",
-                         "DatePublished":  "\/Date(1692271583000)\/",
+                         "DatePublished":  "\/Date(1692267983000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -2576,7 +2576,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Remove-VmsWebhook",
                          "VersionAdded":  "23.2.2",
-                         "DatePublished":  "\/Date(1695916168000)\/",
+                         "DatePublished":  "\/Date(1695912568000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -2588,7 +2588,7 @@
                          "VersionAdded":  "1.0.66",
                          "DatePublished":  "\/Date(1575955525000)\/",
                          "VersionRemoved":  "25.1.39",
-                         "DateRemoved":  "\/Date(1748014837000)\/",
+                         "DateRemoved":  "\/Date(1748011237000)\/",
                          "AliasedTo":  "Get-VmsLicenseDetails"
                      },
                      {
@@ -2598,7 +2598,7 @@
                          "VersionAdded":  "1.0.69",
                          "DatePublished":  "\/Date(1576051327000)\/",
                          "VersionRemoved":  "1.1.4",
-                         "DateRemoved":  "\/Date(1622306412000)\/",
+                         "DateRemoved":  "\/Date(1622302812000)\/",
                          "AliasedTo":  null
                      },
                      {
@@ -2606,9 +2606,9 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-CameraReportV1",
                          "VersionAdded":  "21.1.451385",
-                         "DatePublished":  "\/Date(1625018007000)\/",
+                         "DatePublished":  "\/Date(1625014407000)\/",
                          "VersionRemoved":  "21.2.0",
-                         "DateRemoved":  "\/Date(1635400305000)\/",
+                         "DateRemoved":  "\/Date(1635396705000)\/",
                          "AliasedTo":  null
                      },
                      {
@@ -2616,7 +2616,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Add-GenericEvent",
                          "VersionAdded":  "1.0.30",
-                         "DatePublished":  "\/Date(1557818250000)\/",
+                         "DatePublished":  "\/Date(1557814650000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -2626,7 +2626,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-VmsRestrictedMedia",
                          "VersionAdded":  "24.1.27",
-                         "DatePublished":  "\/Date(1727426172000)\/",
+                         "DatePublished":  "\/Date(1727422572000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -2638,7 +2638,7 @@
                          "VersionAdded":  "1.0.69",
                          "DatePublished":  "\/Date(1576051327000)\/",
                          "VersionRemoved":  "1.1.4",
-                         "DateRemoved":  "\/Date(1622306412000)\/",
+                         "DateRemoved":  "\/Date(1622302812000)\/",
                          "AliasedTo":  null
                      },
                      {
@@ -2646,7 +2646,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "New-VmsLprMatchList",
                          "VersionAdded":  "24.1.6",
-                         "DatePublished":  "\/Date(1722676980000)\/",
+                         "DatePublished":  "\/Date(1722673380000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -2656,9 +2656,9 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-AlarmDefinition",
                          "VersionAdded":  "1.0.10",
-                         "DatePublished":  "\/Date(1555658225000)\/",
+                         "DatePublished":  "\/Date(1555654625000)\/",
                          "VersionRemoved":  "25.1.50",
-                         "DateRemoved":  "\/Date(1749263892000)\/",
+                         "DateRemoved":  "\/Date(1749260292000)\/",
                          "AliasedTo":  "Get-VmsAlarmDefinition"
                      },
                      {
@@ -2676,7 +2676,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Import-VmsRole",
                          "VersionAdded":  "23.1.2",
-                         "DatePublished":  "\/Date(1680940751000)\/",
+                         "DatePublished":  "\/Date(1680937151000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -2686,7 +2686,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-OutputSetting",
                          "VersionAdded":  "1.0.10",
-                         "DatePublished":  "\/Date(1555658225000)\/",
+                         "DatePublished":  "\/Date(1555654625000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -2696,9 +2696,9 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-Input",
                          "VersionAdded":  "1.0.10",
-                         "DatePublished":  "\/Date(1555658225000)\/",
+                         "DatePublished":  "\/Date(1555654625000)\/",
                          "VersionRemoved":  "24.1.5",
-                         "DateRemoved":  "\/Date(1719908403000)\/",
+                         "DateRemoved":  "\/Date(1719904803000)\/",
                          "AliasedTo":  "Get-VmsInput"
                      },
                      {
@@ -2706,7 +2706,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Set-DeviceAcl",
                          "VersionAdded":  "1.0.6",
-                         "DatePublished":  "\/Date(1555397316000)\/",
+                         "DatePublished":  "\/Date(1555393716000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -2716,7 +2716,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-VmsMicrophone",
                          "VersionAdded":  "24.1.5",
-                         "DatePublished":  "\/Date(1719908403000)\/",
+                         "DatePublished":  "\/Date(1719904803000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -2736,7 +2736,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Set-InputSetting",
                          "VersionAdded":  "1.0.10",
-                         "DatePublished":  "\/Date(1555658225000)\/",
+                         "DatePublished":  "\/Date(1555654625000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -2746,7 +2746,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-Snapshot",
                          "VersionAdded":  "1.0.15",
-                         "DatePublished":  "\/Date(1556321925000)\/",
+                         "DatePublished":  "\/Date(1556318325000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -2756,7 +2756,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-VmsLprEvent",
                          "VersionAdded":  "24.1.6",
-                         "DatePublished":  "\/Date(1722676980000)\/",
+                         "DatePublished":  "\/Date(1722673380000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -2768,7 +2768,7 @@
                          "VersionAdded":  "1.0.87",
                          "DatePublished":  "\/Date(1607395261000)\/",
                          "VersionRemoved":  "1.1.4",
-                         "DateRemoved":  "\/Date(1622306412000)\/",
+                         "DateRemoved":  "\/Date(1622302812000)\/",
                          "AliasedTo":  null
                      },
                      {
@@ -2786,7 +2786,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-MetadataSetting",
                          "VersionAdded":  "1.0.10",
-                         "DatePublished":  "\/Date(1555658225000)\/",
+                         "DatePublished":  "\/Date(1555654625000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -2796,7 +2796,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Test-Playback",
                          "VersionAdded":  "1.0.15",
-                         "DatePublished":  "\/Date(1556321925000)\/",
+                         "DatePublished":  "\/Date(1556318325000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -2816,7 +2816,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Find-ConfigurationItem",
                          "VersionAdded":  "21.1.453308",
-                         "DatePublished":  "\/Date(1631939373000)\/",
+                         "DatePublished":  "\/Date(1631935773000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -2826,7 +2826,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "New-AlarmCondition",
                          "VersionAdded":  "1.0.81",
-                         "DatePublished":  "\/Date(1600499098000)\/",
+                         "DatePublished":  "\/Date(1600495498000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -2846,7 +2846,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Set-ConfigurationItem",
                          "VersionAdded":  "1.0.31",
-                         "DatePublished":  "\/Date(1558058313000)\/",
+                         "DatePublished":  "\/Date(1558054713000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -2856,7 +2856,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Add-RegisteredService",
                          "VersionAdded":  "1.0.12",
-                         "DatePublished":  "\/Date(1556086129000)\/",
+                         "DatePublished":  "\/Date(1556082529000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -2866,7 +2866,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-VmsParentItem",
                          "VersionAdded":  "24.1.6",
-                         "DatePublished":  "\/Date(1722676980000)\/",
+                         "DatePublished":  "\/Date(1722673380000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -2876,9 +2876,9 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Select-Site",
                          "VersionAdded":  "1.0.20",
-                         "DatePublished":  "\/Date(1556687465000)\/",
+                         "DatePublished":  "\/Date(1556683865000)\/",
                          "VersionRemoved":  "23.2.1",
-                         "DateRemoved":  "\/Date(1692271583000)\/",
+                         "DateRemoved":  "\/Date(1692267983000)\/",
                          "AliasedTo":  "Select-VmsSite"
                      },
                      {
@@ -2886,7 +2886,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "ConvertFrom-GisPoint",
                          "VersionAdded":  "21.1.451385",
-                         "DatePublished":  "\/Date(1625018007000)\/",
+                         "DatePublished":  "\/Date(1625014407000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -2906,7 +2906,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Remove-VmsBasicUser",
                          "VersionAdded":  "23.1.1",
-                         "DatePublished":  "\/Date(1680049866000)\/",
+                         "DatePublished":  "\/Date(1680046266000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -2916,7 +2916,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "New-VmsLoginProvider",
                          "VersionAdded":  "23.1.1",
-                         "DatePublished":  "\/Date(1680049866000)\/",
+                         "DatePublished":  "\/Date(1680046266000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -2936,7 +2936,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-WhoIsOnline",
                          "VersionAdded":  "1.0.74",
-                         "DatePublished":  "\/Date(1586308069000)\/",
+                         "DatePublished":  "\/Date(1586304469000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -2958,7 +2958,7 @@
                          "VersionAdded":  "1.0.69",
                          "DatePublished":  "\/Date(1576051327000)\/",
                          "VersionRemoved":  "1.1.4",
-                         "DateRemoved":  "\/Date(1622306412000)\/",
+                         "DateRemoved":  "\/Date(1622302812000)\/",
                          "AliasedTo":  null
                      },
                      {
@@ -2966,7 +2966,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Add-VmsHardware",
                          "VersionAdded":  "21.2.0",
-                         "DatePublished":  "\/Date(1635400305000)\/",
+                         "DatePublished":  "\/Date(1635396705000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -2976,7 +2976,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "ConvertTo-GisPoint",
                          "VersionAdded":  "21.2.0",
-                         "DatePublished":  "\/Date(1635400305000)\/",
+                         "DatePublished":  "\/Date(1635396705000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -2986,7 +2986,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-VmsOutput",
                          "VersionAdded":  "24.1.5",
-                         "DatePublished":  "\/Date(1719908403000)\/",
+                         "DatePublished":  "\/Date(1719904803000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -2998,7 +2998,7 @@
                          "VersionAdded":  "21.2.3",
                          "DatePublished":  "\/Date(1642755304000)\/",
                          "VersionRemoved":  "25.1.39",
-                         "DateRemoved":  "\/Date(1748014837000)\/",
+                         "DateRemoved":  "\/Date(1748011237000)\/",
                          "AliasedTo":  "Set-VmsDeviceGeneralSetting"
                      },
                      {
@@ -3006,7 +3006,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-IAlarmClient",
                          "VersionAdded":  "1.0.81",
-                         "DatePublished":  "\/Date(1600499098000)\/",
+                         "DatePublished":  "\/Date(1600495498000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -3016,7 +3016,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-ConfigurationItemProperty",
                          "VersionAdded":  "1.0.80",
-                         "DatePublished":  "\/Date(1600310905000)\/",
+                         "DatePublished":  "\/Date(1600307305000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -3026,7 +3026,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-Translations",
                          "VersionAdded":  "1.0.31",
-                         "DatePublished":  "\/Date(1558058313000)\/",
+                         "DatePublished":  "\/Date(1558054713000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -3036,7 +3036,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-CameraSetting",
                          "VersionAdded":  "1.0.7",
-                         "DatePublished":  "\/Date(1555483155000)\/",
+                         "DatePublished":  "\/Date(1555479555000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -3046,7 +3046,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-Stream",
                          "VersionAdded":  "1.0.7",
-                         "DatePublished":  "\/Date(1555483155000)\/",
+                         "DatePublished":  "\/Date(1555479555000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -3056,7 +3056,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-ConfigurationItem",
                          "VersionAdded":  "1.0.31",
-                         "DatePublished":  "\/Date(1558058313000)\/",
+                         "DatePublished":  "\/Date(1558054713000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -3066,7 +3066,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Set-ConfigurationItemProperty",
                          "VersionAdded":  "1.0.80",
-                         "DatePublished":  "\/Date(1600310905000)\/",
+                         "DatePublished":  "\/Date(1600307305000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -3086,7 +3086,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Set-VmsClientProfile",
                          "VersionAdded":  "23.1.2",
-                         "DatePublished":  "\/Date(1680940751000)\/",
+                         "DatePublished":  "\/Date(1680937151000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -3098,7 +3098,7 @@
                          "VersionAdded":  "1.0.66",
                          "DatePublished":  "\/Date(1575955525000)\/",
                          "VersionRemoved":  "1.1.4",
-                         "DateRemoved":  "\/Date(1622306412000)\/",
+                         "DateRemoved":  "\/Date(1622302812000)\/",
                          "AliasedTo":  null
                      },
                      {
@@ -3106,7 +3106,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-VmsDeviceEvent",
                          "VersionAdded":  "23.2.3",
-                         "DatePublished":  "\/Date(1697049784000)\/",
+                         "DatePublished":  "\/Date(1697046184000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -3116,7 +3116,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Set-MetadataSetting",
                          "VersionAdded":  "1.0.10",
-                         "DatePublished":  "\/Date(1555658225000)\/",
+                         "DatePublished":  "\/Date(1555654625000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -3126,7 +3126,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Add-Stream",
                          "VersionAdded":  "1.0.7",
-                         "DatePublished":  "\/Date(1555483155000)\/",
+                         "DatePublished":  "\/Date(1555479555000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -3136,7 +3136,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-VmsConnectionProfile",
                          "VersionAdded":  "23.2.2",
-                         "DatePublished":  "\/Date(1695916168000)\/",
+                         "DatePublished":  "\/Date(1695912568000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -3156,7 +3156,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-MobileServerInfo",
                          "VersionAdded":  "1.0.56",
-                         "DatePublished":  "\/Date(1569633581000)\/",
+                         "DatePublished":  "\/Date(1569629981000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -3166,7 +3166,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-LoginSettings",
                          "VersionAdded":  "1.0.41",
-                         "DatePublished":  "\/Date(1560927423000)\/",
+                         "DatePublished":  "\/Date(1560923823000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -3176,7 +3176,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-VmsFailoverRecorder",
                          "VersionAdded":  "23.2.1",
-                         "DatePublished":  "\/Date(1692271583000)\/",
+                         "DatePublished":  "\/Date(1692267983000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -3186,7 +3186,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-VmsMetadata",
                          "VersionAdded":  "24.1.5",
-                         "DatePublished":  "\/Date(1719908403000)\/",
+                         "DatePublished":  "\/Date(1719904803000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -3196,7 +3196,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Import-VmsClientProfile",
                          "VersionAdded":  "23.1.2",
-                         "DatePublished":  "\/Date(1680940751000)\/",
+                         "DatePublished":  "\/Date(1680937151000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -3206,7 +3206,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-HardwareSetting",
                          "VersionAdded":  "1.0.7",
-                         "DatePublished":  "\/Date(1555483155000)\/",
+                         "DatePublished":  "\/Date(1555479555000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -3236,7 +3236,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "New-VmsRule",
                          "VersionAdded":  "23.1.3",
-                         "DatePublished":  "\/Date(1682064386000)\/",
+                         "DatePublished":  "\/Date(1682060786000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -3246,7 +3246,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-Bookmark",
                          "VersionAdded":  "1.0.12",
-                         "DatePublished":  "\/Date(1556086129000)\/",
+                         "DatePublished":  "\/Date(1556082529000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -3256,7 +3256,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-VmsRule",
                          "VersionAdded":  "23.1.3",
-                         "DatePublished":  "\/Date(1682064386000)\/",
+                         "DatePublished":  "\/Date(1682060786000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -3266,7 +3266,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-MethodInfo",
                          "VersionAdded":  "1.0.31",
-                         "DatePublished":  "\/Date(1558058313000)\/",
+                         "DatePublished":  "\/Date(1558054713000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -3276,7 +3276,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Export-HardwareCsv",
                          "VersionAdded":  "1.0.56",
-                         "DatePublished":  "\/Date(1569633581000)\/",
+                         "DatePublished":  "\/Date(1569629981000)\/",
                          "VersionRemoved":  "22.3.0",
                          "DateRemoved":  "\/Date(1669815755000)\/",
                          "AliasedTo":  null
@@ -3286,7 +3286,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-RecorderConfig",
                          "VersionAdded":  "1.0.57",
-                         "DatePublished":  "\/Date(1569987384000)\/",
+                         "DatePublished":  "\/Date(1569983784000)\/",
                          "VersionRemoved":  "",
                          "DateRemoved":  "\/Date(-62135568000000)\/",
                          "AliasedTo":  ""
@@ -3296,7 +3296,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Set-XProtectCertificate",
                          "VersionAdded":  "21.1.453308",
-                         "DatePublished":  "\/Date(1631939373000)\/",
+                         "DatePublished":  "\/Date(1631935773000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -3306,9 +3306,9 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-HardwarePassword",
                          "VersionAdded":  "1.0.9",
-                         "DatePublished":  "\/Date(1555574744000)\/",
+                         "DatePublished":  "\/Date(1555571144000)\/",
                          "VersionRemoved":  "23.1.1",
-                         "DateRemoved":  "\/Date(1680049866000)\/",
+                         "DateRemoved":  "\/Date(1680046266000)\/",
                          "AliasedTo":  "Get-VmsHardwarePassword"
                      },
                      {
@@ -3316,7 +3316,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Remove-RegisteredService",
                          "VersionAdded":  "1.0.12",
-                         "DatePublished":  "\/Date(1556086129000)\/",
+                         "DatePublished":  "\/Date(1556082529000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -3326,7 +3326,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Add-EvidenceLock",
                          "VersionAdded":  "1.0.12",
-                         "DatePublished":  "\/Date(1556086129000)\/",
+                         "DatePublished":  "\/Date(1556082529000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -3336,7 +3336,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Resize-Image",
                          "VersionAdded":  "21.1.451385",
-                         "DatePublished":  "\/Date(1625018007000)\/",
+                         "DatePublished":  "\/Date(1625014407000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -3346,7 +3346,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Find-XProtectDevice",
                          "VersionAdded":  "21.1.453308",
-                         "DatePublished":  "\/Date(1631939373000)\/",
+                         "DatePublished":  "\/Date(1631935773000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -3356,7 +3356,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Wait-VmsTask",
                          "VersionAdded":  "21.2.0",
-                         "DatePublished":  "\/Date(1635400305000)\/",
+                         "DatePublished":  "\/Date(1635396705000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -3366,7 +3366,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-VmsStorageRetention",
                          "VersionAdded":  "21.2.0",
-                         "DatePublished":  "\/Date(1635400305000)\/",
+                         "DatePublished":  "\/Date(1635396705000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -3386,7 +3386,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Export-VmsLicenseRequest",
                          "VersionAdded":  "21.2.0",
-                         "DatePublished":  "\/Date(1635400305000)\/",
+                         "DatePublished":  "\/Date(1635396705000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -3416,7 +3416,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Remove-VmsRestrictedMedia",
                          "VersionAdded":  "24.1.27",
-                         "DatePublished":  "\/Date(1727426172000)\/",
+                         "DatePublished":  "\/Date(1727422572000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -3426,9 +3426,9 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-LicenseOverview",
                          "VersionAdded":  "1.1.4",
-                         "DatePublished":  "\/Date(1622306412000)\/",
+                         "DatePublished":  "\/Date(1622302812000)\/",
                          "VersionRemoved":  "25.1.39",
-                         "DateRemoved":  "\/Date(1748014837000)\/",
+                         "DateRemoved":  "\/Date(1748011237000)\/",
                          "AliasedTo":  "Get-VmsLicenseOverview"
                      },
                      {
@@ -3436,7 +3436,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Remove-Bookmark",
                          "VersionAdded":  "1.0.12",
-                         "DatePublished":  "\/Date(1556086129000)\/",
+                         "DatePublished":  "\/Date(1556082529000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -3446,7 +3446,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "New-Alarm",
                          "VersionAdded":  "1.0.81",
-                         "DatePublished":  "\/Date(1600499098000)\/",
+                         "DatePublished":  "\/Date(1600495498000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -3456,7 +3456,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Add-User",
                          "VersionAdded":  "1.0.6",
-                         "DatePublished":  "\/Date(1555397316000)\/",
+                         "DatePublished":  "\/Date(1555393716000)\/",
                          "VersionRemoved":  "22.3.0",
                          "DateRemoved":  "\/Date(1669815755000)\/",
                          "AliasedTo":  null
@@ -3466,7 +3466,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-VmsBasicUserClaim",
                          "VersionAdded":  "23.1.1",
-                         "DatePublished":  "\/Date(1680049866000)\/",
+                         "DatePublished":  "\/Date(1680046266000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -3476,7 +3476,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-VmsArchiveStorage",
                          "VersionAdded":  "1.1.1",
-                         "DatePublished":  "\/Date(1621051923000)\/",
+                         "DatePublished":  "\/Date(1621048323000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -3486,7 +3486,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Start-Export",
                          "VersionAdded":  "1.0.13",
-                         "DatePublished":  "\/Date(1556200603000)\/",
+                         "DatePublished":  "\/Date(1556197003000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -3496,7 +3496,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-VmsCameraMotion",
                          "VersionAdded":  "23.3.33",
-                         "DatePublished":  "\/Date(1718084557000)\/",
+                         "DatePublished":  "\/Date(1718080957000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -3506,7 +3506,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Remove-UserDefinedEvent",
                          "VersionAdded":  "1.0.10",
-                         "DatePublished":  "\/Date(1555658225000)\/",
+                         "DatePublished":  "\/Date(1555654625000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -3526,7 +3526,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Get-VmsLicenseInfo",
                          "VersionAdded":  "25.1.39",
-                         "DatePublished":  "\/Date(1748014837000)\/",
+                         "DatePublished":  "\/Date(1748011237000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -3548,7 +3548,7 @@
                          "VersionAdded":  "1.0.69",
                          "DatePublished":  "\/Date(1576051327000)\/",
                          "VersionRemoved":  "1.1.4",
-                         "DateRemoved":  "\/Date(1622306412000)\/",
+                         "DateRemoved":  "\/Date(1622302812000)\/",
                          "AliasedTo":  null
                      },
                      {
@@ -3556,7 +3556,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "Send-Alarm",
                          "VersionAdded":  "1.0.81",
-                         "DatePublished":  "\/Date(1600499098000)\/",
+                         "DatePublished":  "\/Date(1600495498000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null
@@ -3576,7 +3576,7 @@
                          "Module":  "MilestonePSTools",
                          "Name":  "New-VmsFailoverGroup",
                          "VersionAdded":  "23.2.1",
-                         "DatePublished":  "\/Date(1692271583000)\/",
+                         "DatePublished":  "\/Date(1692267983000)\/",
                          "VersionRemoved":  null,
                          "DateRemoved":  null,
                          "AliasedTo":  null

--- a/docs/commands/en-US/New-VmsLoginProvider.md
+++ b/docs/commands/en-US/New-VmsLoginProvider.md
@@ -14,8 +14,8 @@ Adds a new external login provider to enable authentication by an external ident
 
 ```
 New-VmsLoginProvider [-Name] <String> [-ClientId] <String> [-ClientSecret] <SecureString>
- [[-CallbackPath] <String>] [-Authority] <Uri> [[-UserNameClaim] <String>] [[-Scopes] <String[]>]
- [[-PromptForLogin] <Boolean>] [[-Enabled] <Boolean>] [<CommonParameters>]
+ [[-ClientSecretType] <String>] [[-CallbackPath] <String>] [-Authority] <Uri> [[-UserNameClaim] <String>]
+ [[-Scopes] <String[]>] [[-PromptForLogin] <Boolean>] [[-Enabled] <Boolean>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -77,6 +77,29 @@ as-is, unless you have confirmed with the administrator for your identity manage
 system that users will have a claim named "vms_role", and that the value of this
 claim will match the name of a role in the VMS.
 
+### Example 2
+```powershell
+$providerParams = @{
+    Name             = 'EntraID'
+    ClientId         = '11111111-2222-3333-4444-555555555555'
+    ClientSecret     = 'C263B6DC2B40237A9C13ED9FD84327033B6CD722'
+    ClientSecretType = 'X509Thumbprint'
+    Authority        = 'https://login.microsoftonline.com/contoso.onmicrosoft.com/v2.0'
+    UserNameClaim    = 'preferred_username'
+    Scopes           = 'email', 'profile'
+    ErrorAction      = 'Stop'
+}
+New-VmsLoginProvider @providerParams
+```
+
+Adds an external login provider that uses certificate-based authentication. The
+`-ClientSecret` value is interpreted as the thumbprint of a certificate whose
+private key is available to the identity server. This requires XProtect 2025 R3
+or later.
+
+Note that if the secret is later edited in the Management Client UI, the provider
+reverts to `SharedSecret` authentication.
+
 ## PARAMETERS
 
 ### -Authority
@@ -89,7 +112,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 4
+Position: 5
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -107,7 +130,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 3
+Position: 4
 Default value: /signin-oidc
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -143,6 +166,31 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -ClientSecretType
+Specifies how the `-ClientSecret` value should be interpreted by the external
+login provider. The default is `SharedSecret`, where `-ClientSecret` is the
+client secret issued by the identity provider. When set to `X509Thumbprint`,
+`-ClientSecret` is interpreted as the thumbprint of a certificate used for
+certificate-based authentication (OIDC `private_key_jwt`), and the certificate's
+private key must be available to the identity server. Because the .NET SDK does
+not expose this setting, specifying `X509Thumbprint` configures the provider
+through the XProtect API Gateway and requires XProtect 2025 R3 or later. Note
+that if the secret is later edited in the Management Client UI, the provider
+reverts to `SharedSecret`.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+Accepted values: SharedSecret, X509Thumbprint
+
+Required: False
+Position: 3
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Enabled
 Specifies whether the external login provider should be enabled immediately. The
 default value is `$true`.
@@ -153,7 +201,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 8
+Position: 9
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -188,7 +236,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 7
+Position: 8
 Default value: True
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -207,7 +255,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 6
+Position: 7
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -224,7 +272,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 5
+Position: 6
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/commands/en-US/Set-VmsLoginProvider.md
+++ b/docs/commands/en-US/Set-VmsLoginProvider.md
@@ -14,9 +14,9 @@ Sets the specified properties of an existing external login provider.
 
 ```
 Set-VmsLoginProvider [-LoginProvider] <LoginProvider> [[-Name] <String>] [[-ClientId] <String>]
- [[-ClientSecret] <SecureString>] [[-CallbackPath] <String>] [[-Authority] <Uri>] [[-UserNameClaim] <String>]
- [[-Scopes] <String[]>] [[-PromptForLogin] <Boolean>] [[-Enabled] <Boolean>] [-PassThru] [-WhatIf] [-Confirm]
- [<CommonParameters>]
+ [[-ClientSecret] <SecureString>] [[-ClientSecretType] <String>] [[-CallbackPath] <String>]
+ [[-Authority] <Uri>] [[-UserNameClaim] <String>] [[-Scopes] <String[]>] [[-PromptForLogin] <Boolean>]
+ [[-Enabled] <Boolean>] [-PassThru] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -38,6 +38,19 @@ Set-VmsLoginProvider -LoginProvider Auth0 -ClientSecret (Read-Host -Prompt 'Secr
 If a login provider named 'Auth0' is present, the secret will be requested, and
 then updated in the VMS configuration.
 
+### Example 2
+```powershell
+Get-VmsLoginProvider | Set-VmsLoginProvider -ClientSecret 'C263B6DC2B40237A9C13ED9FD84327033B6CD722' -ClientSecretType X509Thumbprint
+```
+
+Switches the external login provider to certificate-based authentication. The
+`-ClientSecret` value is interpreted as the thumbprint of a certificate whose
+private key is available to the identity server. This is also used to rotate the
+certificate by supplying a new thumbprint. This requires XProtect 2025 R3 or later.
+
+Note that if the secret is later edited in the Management Client UI, the provider
+reverts to `SharedSecret` authentication.
+
 ## PARAMETERS
 
 ### -Authority
@@ -50,7 +63,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 5
+Position: 6
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -68,7 +81,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 4
+Position: 5
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -104,6 +117,33 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -ClientSecretType
+Specifies how the `-ClientSecret` value should be interpreted by the external
+login provider. The default is `SharedSecret`, where `-ClientSecret` is the
+client secret issued by the identity provider. When set to `X509Thumbprint`,
+`-ClientSecret` is interpreted as the thumbprint of a certificate used for
+certificate-based authentication (OIDC `private_key_jwt`), and the certificate's
+private key must be available to the identity server. Use `X509Thumbprint` to
+switch a provider to certificate-based authentication or to rotate the
+certificate by supplying a new thumbprint; `-ClientSecret` is required in that
+case. Because the .NET SDK does not expose this setting, specifying
+`X509Thumbprint` configures the provider through the XProtect API Gateway and
+requires XProtect 2025 R3 or later. Note that if the secret is later edited in
+the Management Client UI, the provider reverts to `SharedSecret`.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+Accepted values: SharedSecret, X509Thumbprint
+
+Required: False
+Position: 4
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Enabled
 Specifies whether the external login provider should be enabled immediately.
 
@@ -113,7 +153,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 9
+Position: 10
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -178,7 +218,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 8
+Position: 9
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -196,7 +236,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 7
+Position: 8
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -213,7 +253,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 6
+Position: 7
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/tests/MilestonePSTools/read-write/New-VmsLoginProvider.integration.ps1
+++ b/tests/MilestonePSTools/read-write/New-VmsLoginProvider.integration.ps1
@@ -31,4 +31,38 @@ Context 'New-VmsLoginProvider' -Skip:($script:SkipReadWriteTests)  {
         $loginProvider.UserNameClaimType | Should -BeExactly $providerParams.UserNameClaim
         $loginProvider.Scopes.Count | Should -BeExactly $providerParams.Scopes.Count
     }
+
+    It 'Can add a certificate-based login provider' {
+        if ([version](Get-VmsManagementServer).Version -lt 25.3) {
+            $null | Should -BeNullOrEmpty -Because "Certificate-based external login providers are not supported until version 2025 R3. Current version is $((Get-VmsManagementServer).Version)."
+            return
+        }
+
+        if (Get-VmsLoginProvider) {
+            Get-VmsLoginProvider | Remove-VmsLoginProvider -Force -Confirm:$false
+        }
+        $thumbprint = 'C263B6DC2B40237A9C13ED9FD84327033B6CD722'
+        $providerParams = @{
+            Name             = 'EntraID'
+            ClientId         = '11111111-2222-3333-4444-555555555555'
+            ClientSecret     = $thumbprint | ConvertTo-SecureString -AsPlainText -Force
+            ClientSecretType = 'X509Thumbprint'
+            Authority        = [uri]'https://login.microsoftonline.com/contoso.onmicrosoft.com/v2.0'
+            UserNameClaim    = 'preferred_username'
+            Scopes           = 'email', 'profile'
+            Verbose          = $true
+            ErrorAction      = 'Stop'
+        }
+        $loginProvider = New-VmsLoginProvider @providerParams
+        $loginProvider | Should -Not -BeNullOrEmpty
+        $loginProvider.ClientId | Should -BeExactly $providerParams.ClientId
+
+        # The SDK LoginProvider object does not surface clientSecretType, so read it
+        # back directly from the API Gateway to confirm certificate-based auth was set.
+        $gatewayUri = (Get-RegisteredService -ServiceType 'e46b7bf9-03ce-44eb-bbdc-8ba16d0aaa80').UriArray | Select-Object -First 1
+        $uriBuilder = [uribuilder]$gatewayUri
+        $uriBuilder.Path = $uriBuilder.Path.TrimEnd('/') + "/rest/v1/loginproviders/$($loginProvider.Id)"
+        $response = Invoke-RestMethod -Uri $uriBuilder.Uri -Headers @{ Authorization = "Bearer $((Get-LoginSettings).IdentityTokenCache.Token)" }
+        $response.data.clientSecretType | Should -BeExactly 'X509Thumbprint'
+    }
 }

--- a/tests/MilestonePSTools/read-write/Set-VmsLoginProvider.integration.ps1
+++ b/tests/MilestonePSTools/read-write/Set-VmsLoginProvider.integration.ps1
@@ -54,4 +54,47 @@ Context 'Set-VmsLoginProvider' -Skip:($script:SkipReadWriteTests) {
             Get-VmsLoginProvider | Remove-VmsLoginProvider -Force -Confirm:$false
         }
     }
+
+    It 'Can switch a login provider to certificate-based authentication and rotate the thumbprint' {
+        if ([version](Get-VmsManagementServer).Version -lt 25.3) {
+            $null | Should -BeNullOrEmpty -Because "Certificate-based external login providers are not supported until version 2025 R3. Current version is $((Get-VmsManagementServer).Version)."
+            return
+        }
+        try {
+            Get-VmsLoginProvider | Remove-VmsLoginProvider -Force -Confirm:$false
+            $providerParams = @{
+                Name          = 'Set-VmsLoginProvider.integration.ps1'
+                ClientId      = '11111111-2222-3333-4444-555555555555'
+                ClientSecret  = 'rLLKh428BmkKqr8G1rgoWZEDL7XKhgy9' | ConvertTo-SecureString -AsPlainText -Force
+                Authority     = [uri]'https://login.microsoftonline.com/contoso.onmicrosoft.com/v2.0'
+                UserNameClaim = 'preferred_username'
+                Scopes        = 'email', 'profile'
+                ErrorAction   = 'Stop'
+            }
+            $null = New-VmsLoginProvider @providerParams
+
+            # Resolve the API Gateway once so we can read back clientSecretType, which
+            # is not surfaced by the SDK LoginProvider object.
+            $gatewayUri = (Get-RegisteredService -ServiceType 'e46b7bf9-03ce-44eb-bbdc-8ba16d0aaa80').UriArray | Select-Object -First 1
+            $getSecretType = {
+                param($Id)
+                $uriBuilder = [uribuilder]$gatewayUri
+                $uriBuilder.Path = $uriBuilder.Path.TrimEnd('/') + "/rest/v1/loginproviders/$Id"
+                (Invoke-RestMethod -Uri $uriBuilder.Uri -Headers @{ Authorization = "Bearer $((Get-LoginSettings).IdentityTokenCache.Token)" }).data.clientSecretType
+            }
+
+            # Switch from shared secret to certificate-based authentication.
+            $firstThumbprint = 'C263B6DC2B40237A9C13ED9FD84327033B6CD722'
+            $provider = Get-VmsLoginProvider -Name $providerParams.Name -ErrorAction Stop
+            $provider | Set-VmsLoginProvider -ClientSecret $firstThumbprint -ClientSecretType X509Thumbprint -ErrorAction Stop
+            & $getSecretType $provider.Id | Should -BeExactly 'X509Thumbprint'
+
+            # Rotate to a second thumbprint.
+            $secondThumbprint = 'A1B2C3D4E5F60718293A4B5C6D7E8F9001122334'
+            Get-VmsLoginProvider -Name $providerParams.Name | Set-VmsLoginProvider -ClientSecret $secondThumbprint -ClientSecretType X509Thumbprint -ErrorAction Stop
+            & $getSecretType $provider.Id | Should -BeExactly 'X509Thumbprint'
+        } finally {
+            Get-VmsLoginProvider | Remove-VmsLoginProvider -Force -Confirm:$false
+        }
+    }
 }


### PR DESCRIPTION
- Added `-ClientSecretType` parameter to `New-VmsLoginProvider` and `Set-VmsLoginProvider` commands to specify the type of client secret (SharedSecret or X509Thumbprint).
- Updated documentation for both commands to reflect the new parameter and its usage.
- Introduced examples demonstrating how to create and update a login provider using certificate-based authentication.
- Modified integration tests to validate the functionality of certificate-based login providers, including the ability to switch and rotate thumbprints.

## Description

XProtect VMS 2025 R3 introduced support for [OpenID Connect private_key_jwt specification](https://openid.net/specs/openid-connect-core-1_0.html#ClientAuthentication) which allows for the IDP service in XProtect to authenticate with an external identity provider using a ClientId and a certificate instead of a ClientId and shared secret.

Configuration of this is not yet available in any graphical user interface - it is only possible through a REST api.

This PR introduces support for configuring certificate-based authentication using the existing `New-VmsLoginProvider` and `Set-VmsLoginProvider` cmdlets.

