### PR TITLE
chore: Add agent onboarding docs and initial domain glossary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,13 @@
+## Agent skills
+
+### Issue tracker
+
+Issues are tracked in GitHub Issues (github.com/milestonesys/MilestonePSTools), using the `gh` CLI. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Default label vocabulary (needs-triage, needs-info, ready-for-agent, ready-for-human, wontfix). See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context — `CONTEXT.md` + `docs/adr/` at the repo root. See `docs/agents/domain.md`.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,32 @@
+# MilestonePSTools
+
+A PowerShell module for configuring, automating, and reporting on a Milestone XProtect video management system (VMS), covering both the hybrid PowerShell/C# cmdlet surface and the underlying `VideoOS.*` SDK it wraps.
+
+## Language
+
+**Hardware**:
+A container representing one network-addressable unit (IP address or hostname) added to a Recording Server. Holds one or more Devices — typically a Camera, and often a Microphone, Speaker, Metadata, and Input/Output devices.
+_Avoid_: Camera, Encoder, Device (when you mean the whole unit)
+
+**Device**:
+The umbrella term for any channel a piece of Hardware exposes — Camera, Microphone, Speaker, Metadata, or Input/Output.
+
+**Camera**:
+A video Device — one of potentially several channels (numbered from 0) exposed by a single Hardware unit.
+_Avoid_: Hardware (a Camera is one channel *of* a Hardware unit, not the unit itself)
+
+**Offline**:
+Ambiguous without qualification — can mean either (a) the Hardware's network connection is unreachable, or (b) a specific Device (usually a Camera) is failing to stream even though the Hardware's network connectivity is healthy (e.g. UDP video blocked by a firewall, or a misbehaving Recording Server / device driver). Users colloquially say "the camera is offline" for both cases and rarely say "hardware." When diagnosing or writing agent output, be explicit about which layer failed rather than reusing "offline" unqualified.
+
+**Site**:
+A whole Milestone XProtect VMS deployment — the Management Server plus every server connected to it (Recording Servers, Event Server, Failover Servers, Mobile Server, etc.) — viewed as one node in a Federated Hierarchy. Broader than "Management Server" in concept, though in a single-server deployment (management server, event server, and recording server all on one box) the two amount to the same thing. The "currently selected site" is the one most cmdlets operate against.
+_Avoid_: System
+
+**Management Server**:
+Specifically the server component of a Site that holds the configuration database and coordinates the rest of the Site's servers, users, and rules. Narrower than "Site" — use "Site" when referring to the deployment as a whole.
+
+**Recording Server**:
+The server component that manages connections to Hardware/Devices, records video, and serves live/playback streams. A Site can have multiple Recording Servers.
+
+**Federated Hierarchy** (Federated Site Hierarchy):
+A set of Sites linked parent/child so a central Site can reach into child Sites. `Connect-Vms -IncludeChildSites` logs into the whole hierarchy at once.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,51 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root, or
+- **`CONTEXT-MAP.md`** at the repo root if it exists — it points at one `CONTEXT.md` per context. Read each one relevant to the topic.
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in. In multi-context repos, also check `src/<context>/docs/adr/` for context-scoped decisions.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The `/domain-modeling` skill (reached via `/grill-with-docs` and `/improve-codebase-architecture`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+Single-context repo (most repos):
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-event-sourced-orders.md
+│   └── 0002-postgres-for-write-model.md
+└── src/
+```
+
+Multi-context repo (presence of `CONTEXT-MAP.md` at the root):
+
+```
+/
+├── CONTEXT-MAP.md
+├── docs/adr/                          ← system-wide decisions
+└── src/
+    ├── ordering/
+    │   ├── CONTEXT.md
+    │   └── docs/adr/                  ← context-specific decisions
+    └── billing/
+        ├── CONTEXT.md
+        └── docs/adr/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/domain-modeling`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (event-sourced orders) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,45 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## Pull requests as a triage surface
+
+**PRs as a request surface: yes.** _(External contributors regularly send PRs via fork — see the README's fork/PR contributing workflow — so `/triage` also walks open PRs from non-member authors.)_
+
+When set to `yes`, PRs run through the same labels and states as issues, using the `gh pr` equivalents:
+
+- **Read a PR**: `gh pr view <number> --comments` and `gh pr diff <number>` for the diff.
+- **List external PRs for triage**: `gh pr list --state open --json number,title,body,labels,author,authorAssociation,comments` then keep only `authorAssociation` of `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, or `NONE` (drop `OWNER`/`MEMBER`/`COLLABORATOR`).
+- **Comment / label / close**: `gh pr comment`, `gh pr edit --add-label`/`--remove-label`, `gh pr close`.
+
+GitHub shares one number space across issues and PRs, so a bare `#42` may be either — resolve with `gh pr view 42` and fall back to `gh issue view 42`.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.
+
+## Wayfinding operations
+
+Used by `/wayfinder`. The **map** is a single issue with **child** issues as tickets.
+
+- **Map**: a single issue labelled `wayfinder:map`, holding the Notes / Decisions-so-far / Fog body. `gh issue create --label wayfinder:map`.
+- **Child ticket**: an issue linked to the map as a GitHub sub-issue (`gh api` on the sub-issues endpoint). Where sub-issues aren't enabled, add the child to a task list in the map body and put `Part of #<map>` at the top of the child body. Labels: `wayfinder:<type>` (`research`/`prototype`/`grilling`/`task`). Once claimed, the ticket is assigned to the driving dev.
+- **Blocking**: GitHub's **native issue dependencies** — the canonical, UI-visible representation. Add an edge with `gh api --method POST repos/<owner>/<repo>/issues/<child>/dependencies/blocked_by -F issue_id=<blocker-db-id>`, where `<blocker-db-id>` is the blocker's numeric **database id** (`gh api repos/<owner>/<repo>/issues/<n> --jq .id`, _not_ the `#number` or `node_id`). GitHub reports `issue_dependencies_summary.blocked_by` (open blockers only — the live gate). Where dependencies aren't available, fall back to a `Blocked by: #<n>, #<n>` line at the top of the child body. A ticket is unblocked when every blocker is closed.
+- **Frontier query**: list the map's open children (`gh issue list --state open`, scoped to the map's sub-issues / task list), drop any with an open blocker (`issue_dependencies_summary.blocked_by > 0`, or an open issue in the `Blocked by` line) or an assignee; first in map order wins.
+- **Claim**: `gh issue edit <n> --add-assignee @me` — the session's first write.
+- **Resolve**: `gh issue comment <n> --body "<answer>"`, then `gh issue close <n>`, then append a context pointer (gist + link) to the map's Decisions-so-far.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`              | `needs-triage`        | Maintainer needs to evaluate this issue  |
+| `needs-info`                | `needs-info`          | Waiting on reporter for more information |
+| `ready-for-agent`           | `ready-for-agent`     | Fully specified, ready for an AFK agent  |
+| `ready-for-human`           | `ready-for-human`     | Requires human implementation            |
+| `wontfix`                   | `wontfix`             | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+All five labels now exist verbatim in this repo's tracker (the four missing ones were created to match the canonical vocabulary 1:1, rather than overloading existing labels like `help wanted`).


### PR DESCRIPTION
## Description
Scaffolds documentation for AI coding agents working in this repo, and seeds an initial domain glossary:

- `AGENTS.md` — entry point pointing agents at the docs below
- `docs/agents/issue-tracker.md` — how to use `gh` for issues/PRs; external PRs are now treated as a triage surface too (this repo accepts fork-based contributions, e.g. #194, #192, #177)
- `docs/agents/triage-labels.md` — maps the canonical triage roles (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`) to actual repo labels. The four missing labels were created to match 1:1 rather than overloading existing labels like `help wanted`.
- `docs/agents/domain.md` — how agents should consume `CONTEXT.md`/ADRs before exploring the codebase
- `CONTEXT.md` — new glossary, currently covering two clusters worked out via a `/grill-with-docs` session: Hardware/Device/Camera (including the ambiguity around what "offline" means), and Site/Management Server/Recording Server/Federated Hierarchy

## Related Issue
None — internal tooling/process change, not user-facing.

## Motivation and Context
Gives AI agents (and new contributors) a consistent starting point for this repo's conventions and domain vocabulary, reducing the chance an agent conflates Hardware with Camera, or Site with Management Server, when reasoning about the codebase.

## How Has This Been Tested?
Docs-only change; no code paths affected. Verified the new GitHub labels were created (`gh label list`) and that the triage vocabulary now maps 1:1.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.